### PR TITLE
ci: fixed global reference to currentBuild

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -242,7 +242,7 @@ pipeline {
                     steps {
                         script {
                             executeNpmLogin()
-                            nodeCmd("npm run release -- --no-verify --release-as ${getCurrentVersion()}-devel.${current.startTimeInMillis} --skip.commit --skip.tag --skip.changelog")
+                            nodeCmd("npm run release -- --no-verify --release-as ${getCurrentVersion()}-devel.${currentBuild.startTimeInMillis} --skip.commit --skip.tag --skip.changelog")
                             nodeCmd("NODE_ENV=\"production\" npm publish --tag devel")
                         }
                     }


### PR DESCRIPTION
in the previous pr there was an error that only emerged when the affected stage was run (publish devel on npm)