### PR TITLE
feat!: added windowObj key to the theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"deploy": "npm run prepublishOnly && rm -rf $PKG_PATH/node_modules/@zextras/carbonio-design-system/dist/ && cp -r dist/ $PKG_PATH/node_modules/@zextras/carbonio-design-system/dist/ && cp package.json $PKG_PATH/node_modules/@zextras/carbonio-design-system/ && cd $PKG_PATH/node_modules/@zextras/carbonio-design-system/ && rm -rf node_modules && npm i --only=prod",
 		"postinstall": "is-ci || husky install",
 		"postpublish": "pinst --enable",
-		"type-check": "tsc"
+		"type-check": "tsc --noEmit"
 	},
 	"repository": {
 		"type": "git",

--- a/src/components/display/Dropdown.jsx
+++ b/src/components/display/Dropdown.jsx
@@ -5,7 +5,15 @@
  */
 
 /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
-import React, { useState, useRef, useEffect, useLayoutEffect, useCallback, useMemo } from 'react';
+import React, {
+	useState,
+	useRef,
+	useEffect,
+	useLayoutEffect,
+	useCallback,
+	useMemo,
+	useContext
+} from 'react';
 import { createPopper } from '@popperjs/core';
 import styled, { css } from 'styled-components';
 import PropTypes from 'prop-types';
@@ -19,6 +27,7 @@ import { useKeyboard, getKeyboardPreset } from '../../hooks/useKeyboard';
 import { useCombinedRefs } from '../../hooks/useCombinedRefs';
 import { pseudoClasses } from '../utilities/functions';
 import { Theme } from '../../theme/theme';
+import { ThemeContext } from '../../theme/theme-context-provider';
 
 const ContainerEl = styled(Container)`
 	user-select: none;
@@ -235,6 +244,7 @@ const Dropdown = React.forwardRef(function DropdownFn(
 	},
 	ref
 ) {
+	const { windowObj } = useContext(ThemeContext);
 	const [open, setOpen] = useState(forceOpen);
 	const openRef = useRef(open);
 	const dropdownRef = useCombinedRefs(dropdownListRef);
@@ -380,19 +390,19 @@ const Dropdown = React.forwardRef(function DropdownFn(
 	useEffect(() => {
 		openRef.current = open;
 		open &&
-			setTimeout(() => window.top.document.addEventListener('click', clickOutsidePopper, true), 1);
+			setTimeout(() => windowObj.document.addEventListener('click', clickOutsidePopper, true), 1);
 		contextMenu &&
 			open &&
 			setTimeout(
-				() => window.top.document.addEventListener('contextmenu', clickOutsidePopper, true),
+				() => windowObj.document.addEventListener('contextmenu', clickOutsidePopper, true),
 				1
 			);
 
 		return () => {
-			window.top.document.removeEventListener('click', clickOutsidePopper, true);
-			window.top.document.removeEventListener('contextmenu', clickOutsidePopper, true);
+			windowObj.document.removeEventListener('click', clickOutsidePopper, true);
+			windowObj.document.removeEventListener('contextmenu', clickOutsidePopper, true);
 		};
-	}, [open, closePopper, clickOutsidePopper, contextMenu]);
+	}, [open, closePopper, clickOutsidePopper, contextMenu, windowObj.document]);
 
 	useEffect(() => {
 		if (open && !disableAutoFocus) {

--- a/src/components/display/Popover.jsx
+++ b/src/components/display/Popover.jsx
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React, { useEffect, useState, useRef, useCallback } from 'react';
+import React, { useEffect, useState, useRef, useCallback, useContext } from 'react';
 import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import Popper from './Popper';
 import { useCombinedRefs } from '../../hooks/useCombinedRefs';
+import { ThemeContext } from '../../theme/theme-context-provider';
 
 const PopoverContainer = styled.div`
 	padding: ${(props) => props.theme.sizes.padding.small};
@@ -24,6 +25,7 @@ const Popover = React.forwardRef(function PopoverFn(
 	{ children, open, anchorEl, activateOnHover, placement, onClose, styleAsModal, ...rest },
 	ref
 ) {
+	const { windowObj } = useContext(ThemeContext);
 	const innerRef = useRef(undefined);
 	const popoverRef = useCombinedRefs(ref, innerRef);
 	const [innerOpen, setInnerOpen] = useState(false);
@@ -89,16 +91,16 @@ const Popover = React.forwardRef(function PopoverFn(
 		if (activateOnHover && anchorEl.current) {
 			anchorEl.current.addEventListener('mouseenter', onMouseEnter);
 			anchorEl.current.addEventListener('mouseleave', onMouseLeave);
-			window.top.document.addEventListener('scroll', closePopover);
+			windowObj.document.addEventListener('scroll', closePopover);
 			const anchorSave = anchorEl.current;
 			return () => {
 				anchorSave.removeEventListener('mouseenter', onMouseEnter);
 				anchorSave.removeEventListener('mouseleave', onMouseLeave);
-				window.top.document.removeEventListener('scroll', closePopover);
+				windowObj.document.removeEventListener('scroll', closePopover);
 			};
 		}
 		return () => undefined;
-	}, [anchorEl, activateOnHover, onMouseEnter, onMouseLeave, closePopover]);
+	}, [anchorEl, activateOnHover, onMouseEnter, onMouseLeave, closePopover, windowObj.document]);
 
 	return (
 		<Popper

--- a/src/components/display/Popper.jsx
+++ b/src/components/display/Popper.jsx
@@ -5,13 +5,14 @@
  */
 
 /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
-import React, { useLayoutEffect, useEffect, useRef, useCallback, useMemo } from 'react';
+import React, { useLayoutEffect, useEffect, useRef, useCallback, useMemo, useContext } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { createPopper } from '@popperjs/core';
 import Portal from '../utilities/Portal';
 import { useCombinedRefs } from '../../hooks/useCombinedRefs';
 import { useKeyboard } from '../../hooks/useKeyboard';
+import { ThemeContext } from '../../theme/theme-context-provider';
 
 function getAnchorEl(anchorEl) {
 	return typeof anchorEl === 'function' ? anchorEl() : anchorEl.current;
@@ -43,6 +44,7 @@ const Popper = React.forwardRef(function PopperFn(
 	},
 	ref
 ) {
+	const { windowObj } = useContext(ThemeContext);
 	const innerRef = useRef(undefined);
 	const popperRef = useCombinedRefs(ref, innerRef);
 	const wrapperRef = useRef(undefined);
@@ -131,11 +133,11 @@ const Popper = React.forwardRef(function PopperFn(
 
 	useEffect(() => {
 		if (open) {
-			setTimeout(() => window.top.document.addEventListener('click', closePopper), 1);
-			return () => window.top.document.removeEventListener('click', closePopper);
+			setTimeout(() => windowObj.document.addEventListener('click', closePopper), 1);
+			return () => windowObj.document.removeEventListener('click', closePopper);
 		}
 		return () => undefined;
-	}, [open, closePopper]);
+	}, [open, closePopper, windowObj.document]);
 
 	useEffect(() => {
 		if (open) {

--- a/src/components/feedback/CustomModal.jsx
+++ b/src/components/feedback/CustomModal.jsx
@@ -5,7 +5,7 @@
  */
 
 /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
-import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useMemo, useCallback, useRef, useContext } from 'react';
 import PropTypes from 'prop-types';
 import Container from '../layout/Container';
 import Portal from '../utilities/Portal';
@@ -20,12 +20,14 @@ import {
 	ModalWrapper,
 	ModalContent
 } from './Modal';
+import { ThemeContext } from '../../theme/theme-context-provider';
 
 const CustomModal = React.forwardRef(function ModalFn(
 	{ background, size, open, onClose, children, disablePortal, maxHeight, zIndex, ...rest },
 	ref
 ) {
 	const [delayedOpen, setDelayedOpen] = useState(false);
+	const { windowObj } = useContext(ThemeContext);
 
 	const innerRef = useRef(undefined);
 	const modalRef = useCombinedRefs(ref, innerRef);
@@ -62,23 +64,23 @@ const CustomModal = React.forwardRef(function ModalFn(
 
 	useEffect(() => {
 		if (open) {
-			const defaultOverflowY = window.top.document.body.style.overflowY;
-			const defaultPaddingRight = window.top.document.body.style.paddingRight;
+			const defaultOverflowY = windowObj.document.body.style.overflowY;
+			const defaultPaddingRight = windowObj.document.body.style.paddingRight;
 
-			window.top.document.body.style.overflowY = 'hidden';
+			windowObj.document.body.style.overflowY = 'hidden';
 			isBodyOverflowing(modalRef) &&
-				(window.top.document.body.style.paddingRight = `${getScrollbarSize()}px`);
+				(windowObj.document.body.style.paddingRight = `${getScrollbarSize()}px`);
 
 			return () => {
-				window.top.document.body.style.overflowY = defaultOverflowY;
-				window.top.document.body.style.paddingRight = defaultPaddingRight;
+				windowObj.document.body.style.overflowY = defaultOverflowY;
+				windowObj.document.body.style.paddingRight = defaultPaddingRight;
 			};
 		}
 		return () => undefined;
-	}, [modalRef, open]);
+	}, [modalRef, open, windowObj.document.body.style]);
 
 	useEffect(() => {
-		const focusedElement = window.top.document.activeElement;
+		const focusedElement = windowObj.document.activeElement;
 
 		if (open) {
 			modalContentRef.current.focus();
@@ -93,7 +95,7 @@ const CustomModal = React.forwardRef(function ModalFn(
 			endSentinelRefSave && endSentinelRefSave.removeEventListener('focus', onEndSentinelFocus);
 			open && focusedElement.focus();
 		};
-	}, [open, onStartSentinelFocus, onEndSentinelFocus]);
+	}, [open, onStartSentinelFocus, onEndSentinelFocus, windowObj.document.activeElement]);
 
 	useEffect(() => {
 		setTimeout(() => setDelayedOpen(open), 1);

--- a/src/components/feedback/Snackbar.jsx
+++ b/src/components/feedback/Snackbar.jsx
@@ -5,7 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useContext, useEffect } from 'react';
 import styled, { css } from 'styled-components';
 import { useScreenMode } from '../../hooks/useScreenMode';
 import Button from '../basic/Button';
@@ -66,7 +66,6 @@ const Snackbar = React.forwardRef(function SnackbarFn(
 	ref
 ) {
 	const screenMode = useScreenMode(target);
-
 	const handleClick = useCallback(() => {
 		onActionClick ? onActionClick() : onClose && onClose();
 	}, [onActionClick, onClose]);
@@ -141,7 +140,7 @@ Snackbar.propTypes = {
 	onActionClick: PropTypes.func,
 	/** Callback to handle Snackbar closing */
 	onClose: PropTypes.func,
-	/** Disable the autoHide funtionality */
+	/** Disable the autoHide functionality */
 	disableAutoHide: PropTypes.bool,
 	/** Hide the button in the Snackbar */
 	hideButton: PropTypes.bool,
@@ -165,7 +164,7 @@ Snackbar.defaultProps = {
 	hideButton: false,
 	zIndex: 1000,
 	autoHideTimeout: 4000,
-	target: window.top,
+	target: window,
 	onActionClick: undefined,
 	onClose: undefined,
 	disablePortal: false,

--- a/src/components/inputs/EmailComposerInput.jsx
+++ b/src/components/inputs/EmailComposerInput.jsx
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef, useCallback, useContext } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import Text from '../basic/Text';
+import { ThemeContext } from '../../theme/theme-context-provider';
 
 const PlaceholderInline = styled(Text)`
 	font-size: ${(props) => props.theme.sizes.font.medium};
@@ -111,10 +112,10 @@ const EmailComposerInput = React.forwardRef(function EmailComposerInputFn(
 	const [active, setActive] = useState(false);
 	const [hasFocus, setHasFocus] = useState(false);
 	const inputRef = useRef(undefined);
-
+	const { windowObj } = useContext(ThemeContext);
 	const checkIfSetActive = useCallback(() => {
-		setActive(window.top.document.activeElement === inputRef.current || inputRef.current.value);
-	}, [setActive, inputRef]);
+		setActive(windowObj.document.activeElement === inputRef.current || inputRef.current.value);
+	}, [windowObj.document.activeElement]);
 
 	const onFocus = useCallback(() => {
 		checkIfSetActive();

--- a/src/components/utilities/ModalManager.jsx
+++ b/src/components/utilities/ModalManager.jsx
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React, { useCallback, createContext, useReducer } from 'react';
+import React, { useCallback, createContext, useReducer, useContext } from 'react';
 import Modal from '../feedback/Modal';
 import CustomModal from '../feedback/CustomModal';
+import { ThemeContext } from '../../theme/theme-context-provider';
 
 const ModalManagerContext = createContext();
 
@@ -26,7 +27,7 @@ function modalsReducer(state, action) {
 
 function ModalManager({ children }) {
 	const [modals, dispatchModal] = useReducer(modalsReducer, []);
-
+	const { windowObj } = useContext(ThemeContext);
 	const createModal = useCallback(
 		(
 			{
@@ -54,10 +55,10 @@ function ModalManager({ children }) {
 			},
 			custom = false
 		) => {
-			const overflow = window.top.document.body.style.overflowY;
+			const overflow = windowObj.document.body.style.overflowY;
 			const handleClose = () => {
 				if (onClose) onClose();
-				if (overflow) window.top.document.body.style.overflowY = overflow;
+				if (overflow) windowObj.document.body.style.overflowY = overflow;
 			};
 
 			const handleConfirmClick = () => {
@@ -121,7 +122,7 @@ function ModalManager({ children }) {
 
 			return closeModal;
 		},
-		[dispatchModal]
+		[windowObj.document.body.style]
 	);
 
 	return (

--- a/src/components/utilities/Portal.jsx
+++ b/src/components/utilities/Portal.jsx
@@ -4,19 +4,21 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React from 'react';
+import React, { useContext } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
+import { ThemeContext } from '../../theme/theme-context-provider';
 
 const Portal = React.forwardRef(function PortalFn(
 	{ children, container, show, disablePortal = false },
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	ref
 ) {
+	const { windowObj } = useContext(ThemeContext);
 	if (disablePortal) return children;
 	if (!show) return null;
 
-	return ReactDOM.createPortal(children, container || window.top.document.body);
+	return ReactDOM.createPortal(children, container || windowObj.document.body);
 });
 
 Portal.propTypes = {
@@ -24,7 +26,7 @@ Portal.propTypes = {
 	children: PropTypes.node,
 	/**
 	 * HTML node where to insert the Portal's children.
-	 * The default value is 'window.top.document'.
+	 * The default value is 'windowObj.document'.
 	 * */
 	container: PropTypes.instanceOf(Element),
 	/** Flag to show or hide Portal's content */

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -28,6 +28,7 @@ export interface ThemeColorObj {
 
 // augment this interface to extend theme type
 export interface ThemeObj {
+	windowObj: Window;
 	breakpoints: {
 		width: number;
 		aspectRatio: number;
@@ -74,6 +75,7 @@ export interface ThemeObj {
 }
 
 export const Theme: ThemeObj = {
+	windowObj: window,
 	breakpoints: {
 		width: 960,
 		aspectRatio: 2 / 3


### PR DESCRIPTION
BREAKING CHANGE: `window` is used as default reference for events and portals instead of window.top