### PR TITLE
Text with tooltip label and props

### DIFF
--- a/src/components/basic/TextWithTooltip.tsx
+++ b/src/components/basic/TextWithTooltip.tsx
@@ -4,21 +4,30 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { Placement } from '@popperjs/core/lib/enums';
 import React from 'react';
 import { Tooltip } from '../display/Tooltip';
 import { Text, TextProps } from './Text';
 
 interface TextWithTooltipProps extends TextProps {
 	/** Text content */
-	children: string;
+	children: string | React.ReactNode;
+	tooltipMaxWidth?: string;
+	tooltipPlacement?: Placement;
 }
 
 const TextWithTooltip = React.forwardRef<HTMLDivElement, TextWithTooltipProps>(function TextFn(
-	{ children, ...rest },
+	{ children, tooltipMaxWidth, tooltipPlacement, ...rest },
 	ref
 ) {
 	return (
-		<Tooltip label={children} overflowTooltip>
+		<Tooltip
+			label={children}
+			overflowTooltip
+			overflow="break-word"
+			maxWidth={tooltipMaxWidth}
+			placement={tooltipPlacement}
+		>
 			<Text ref={ref} {...rest}>
 				{children}
 			</Text>

--- a/src/components/display/Chip.tsx
+++ b/src/components/display/Chip.tsx
@@ -139,7 +139,7 @@ const ChipContainer = styled(Container)<{
 		}
 	}};
 	cursor: ${({ onClick, onDoubleClick }): SimpleInterpolation =>
-		(onClick || onDoubleClick) && 'pointer'};
+		onClick || onDoubleClick ? 'pointer' : 'default'};
 `;
 
 const SIZES: Record<

--- a/src/components/display/Tooltip.tsx
+++ b/src/components/display/Tooltip.tsx
@@ -56,7 +56,7 @@ const TooltipWrapperWithCss = styled(TooltipWrapper)<{ $maxWidth: string }>`
 
 interface TooltipProps extends TextProps {
 	/** Tooltip text */
-	label: string | undefined;
+	label: string | React.ReactNode | undefined;
 	/** Tooltip placement */
 	placement?: Placement;
 	/** Tooltip max-width css property */

--- a/src/components/inputs/IconCheckbox.tsx
+++ b/src/components/inputs/IconCheckbox.tsx
@@ -86,7 +86,7 @@ interface IconCheckboxProps extends Omit<ContainerProps, 'margin'> {
 	/** IconCheckbox size */
 	size?: 'small' | 'regular' | 'large';
 	/** IconCheckbox margin */
-	margin: keyof ThemeObj['sizes']['padding'];
+	margin?: keyof ThemeObj['sizes']['padding'];
 	/** IconCheckbox value */
 	value?: boolean;
 	/** change callback */

--- a/src/components/utilities/Drop.tsx
+++ b/src/components/utilities/Drop.tsx
@@ -183,4 +183,4 @@ const Drop = React.forwardRef<HTMLDivElement, DropProps>(function DropFn(
 	);
 });
 
-export { Drop, DropProps };
+export { Drop, DropProps, DragObj };


### PR DESCRIPTION
- Fixed IconCheckbox _margin_ prop optionality
- Restored previous Chip's _cursor_ behaviour: if there is no click/doubleClick handlers defined _cursor_ is set to _default_ (issue reported by UX designer on validation of IRIS-2968)
- Exported _DragObj_ type of Drop component
- Changed TextWithTooltip props to enable fine control on tooltip's behavior and to handle a React element as tooltip label (needed for IRIS-2400)