### PR TITLE
fix: avoid contents inside modal to lose focus on change of active node

### DIFF
--- a/src/components/basic/TextWithTooltip.md
+++ b/src/components/basic/TextWithTooltip.md
@@ -6,7 +6,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 ```jsx
 import { Container } from '@zextras/carbonio-design-system';
-import TextWithTooltip from '../basic/TextWithTooltip.jsx';
 <Container orientation="horizontal" mainAlignment="space-around" height={100}>
 	<TextWithTooltip
 		size="large"

--- a/src/components/feedback/CustomModal.jsx
+++ b/src/components/feedback/CustomModal.jsx
@@ -95,7 +95,7 @@ const CustomModal = React.forwardRef(function ModalFn(
 			endSentinelRefSave && endSentinelRefSave.removeEventListener('focus', onEndSentinelFocus);
 			open && focusedElement.focus();
 		};
-	}, [open, onStartSentinelFocus, onEndSentinelFocus, windowObj.document.activeElement]);
+	}, [open, onStartSentinelFocus, onEndSentinelFocus, windowObj]);
 
 	useEffect(() => {
 		setTimeout(() => setDelayedOpen(open), 1);

--- a/src/components/feedback/Modal.jsx
+++ b/src/components/feedback/Modal.jsx
@@ -334,7 +334,7 @@ const Modal = React.forwardRef(function ModalFn(
 			endSentinelRefSave && endSentinelRefSave.removeEventListener('focus', onEndSentinelFocus);
 			open && focusedElement.focus();
 		};
-	}, [open, onStartSentinelFocus, onEndSentinelFocus, windowObj.document.activeElement]);
+	}, [open, onStartSentinelFocus, onEndSentinelFocus, windowObj]);
 
 	useEffect(() => {
 		setTimeout(() => setDelayedOpen(open), 1);

--- a/src/components/inputs/EmailComposerInput.jsx
+++ b/src/components/inputs/EmailComposerInput.jsx
@@ -115,7 +115,7 @@ const EmailComposerInput = React.forwardRef(function EmailComposerInputFn(
 	const { windowObj } = useContext(ThemeContext);
 	const checkIfSetActive = useCallback(() => {
 		setActive(windowObj.document.activeElement === inputRef.current || inputRef.current.value);
-	}, [windowObj.document.activeElement]);
+	}, [windowObj]);
 
 	const onFocus = useCallback(() => {
 		checkIfSetActive();


### PR DESCRIPTION
Set the dependency to only windowObj instead of windowObj.document.activeElement
in order to avoid the hook to re-run each time the activeElement change.
This change was causing for modals a reset of the focused element to the modal itself,
making the input inside losing focus while typing.

refs: CDS-54