### PR TITLE
fix: avoid contents inside modal to lose focus on change of active node

### DIFF
--- a/src/components/basic/TextWithTooltip.md
+++ b/src/components/basic/TextWithTooltip.md
@@ -31,7 +31,6 @@ import { Container } from '@zextras/carbonio-design-system';
 ### Change TextWithTooltip's trigger delay
 ```jsx
 import { Container } from '@zextras/carbonio-design-system';
-import TextWithTooltip from '../basic/TextWithTooltip.jsx';
 <Container orientation="horizontal" mainAlignment="space-around" height={100}>
 	<TextWithTooltip
         label="3 seconds before tooltip trigger Lorem ipsum dolor sit amet"

--- a/src/components/feedback/CustomModal.tsx
+++ b/src/components/feedback/CustomModal.tsx
@@ -123,7 +123,7 @@ const CustomModal = React.forwardRef<HTMLDivElement, CustomModalProps>(function 
 			endSentinelRefSave && endSentinelRefSave.removeEventListener('focus', onEndSentinelFocus);
 			open && focusedElement && focusedElement.focus();
 		};
-	}, [open, onStartSentinelFocus, onEndSentinelFocus, windowObj.document.activeElement]);
+	}, [open, onStartSentinelFocus, onEndSentinelFocus, windowObj]);
 
 	useEffect(() => {
 		setTimeout(() => setDelayedOpen(open), 1);

--- a/src/components/feedback/Modal.tsx
+++ b/src/components/feedback/Modal.tsx
@@ -346,7 +346,7 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>(function ModalFn(
 			endSentinelRefSave && endSentinelRefSave.removeEventListener('focus', onEndSentinelFocus);
 			open && focusedElement && (focusedElement as HTMLElement).focus();
 		};
-	}, [open, onStartSentinelFocus, onEndSentinelFocus, windowObj.document.activeElement]);
+	}, [open, onStartSentinelFocus, onEndSentinelFocus, windowObj]);
 
 	useEffect(() => {
 		setTimeout(() => setDelayedOpen(open), 1);

--- a/src/components/inputs/EmailComposerInput.tsx
+++ b/src/components/inputs/EmailComposerInput.tsx
@@ -137,7 +137,7 @@ const EmailComposerInput = React.forwardRef<HTMLDivElement, EmailComposerInputPr
 
 		const checkIfSetActive = useCallback(() => {
 			setActive(windowObj.document.activeElement === inputRef.current || !!inputRef.current?.value);
-		}, [windowObj.document.activeElement]);
+		}, [windowObj]);
 
 		const onFocus = useCallback(() => {
 			checkIfSetActive();

--- a/src/components/inputs/Input.md
+++ b/src/components/inputs/Input.md
@@ -13,14 +13,16 @@ import styled from 'styled-components';
 const [value, setValue] = useState('Some Controlled value');
 const [value2, setValue2] = useState('');
 
-const StyledContainer = styled(Container)`
-  & > * {
-    width: 48%;
-  }
-`;
-
-<StyledContainer orientation="horizontal" mainAlignment="space-around" wrap="wrap" style={{ margin: 'auto' }} crossAlignment="flex-start">
-    <Input autoComplete="on" autoFocus label="Input" defaultValue="Default Value" />
+<Container orientation="horizontal" mainAlignment="space-around" wrap="wrap" style={{ margin: 'auto' }} crossAlignment="flex-start">
+  <Container width="48%">
+    <Input autoComplete="on" label="Input" defaultValue="Default Value" />
+    <Input 
+        label="Input with custom icon"
+        CustomIcon={({ hasFocus }) => <Icon icon="AgendaOutline" size="large" color={hasFocus ? 'primary' : 'text'} />}
+    />
+    <Input />
+  </Container>
+  <Container width="48%">
     <Input
         label="Some other Input"
         value={value}
@@ -30,10 +32,6 @@ const StyledContainer = styled(Container)`
             }
         }
         backgroundColor="gray6"
-    />
-    <Input 
-        label="Input with custom icon"
-        CustomIcon={({ hasFocus }) => <Icon icon="AgendaOutline" size="large" color={hasFocus ? 'primary' : 'text'} />}
     />
     <Input
         label="Input with onEnter"
@@ -47,9 +45,9 @@ const StyledContainer = styled(Container)`
         onEnter={(e) => { console.log('onEnter called with text', e.target.value) }}
         backgroundColor="gray6"
     />
-    <Input />
     <Input description="empty with description" />
-</StyledContainer>
+  </Container>
+</Container>
 ```
 
 #### Colors

--- a/src/components/inputs/Input.test.tsx
+++ b/src/components/inputs/Input.test.tsx
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { screen } from '@testing-library/dom';
+import { waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React, { useCallback, useState } from 'react';
+import { render } from '../../test-utils';
+import { Button } from '../basic/Button';
+import { Modal } from '../feedback/Modal';
+import { Input } from './Input';
+
+const ModalWithInput = (): JSX.Element => {
+	const [open, setOpen] = useState(false);
+	const clickHandler = (): void => setOpen(true);
+	const closeHandler = (): void => setOpen(false);
+
+	const [inputValue, setInputValue] = useState('');
+	const [inputHasError, setInputHasError] = useState(false);
+	const inputLabel = 'Input Label';
+	const inputLabelError = 'Input value longer than 140 characters';
+
+	const handleChangeValue = useCallback<React.ChangeEventHandler<HTMLInputElement>>((e) => {
+		if (e.target.value.length > 140) {
+			setInputHasError(true);
+			setInputValue(e.target.value.substring(0, 140));
+		} else {
+			setInputHasError(false);
+			setInputValue(e.target.value);
+		}
+	}, []);
+
+	return (
+		<>
+			<Button onClick={clickHandler} label="Open modal" />
+			<Modal open={open} title="Modal title" onConfirm={closeHandler} onClose={closeHandler}>
+				<Input
+					value={inputValue}
+					onChange={handleChangeValue}
+					label={inputHasError ? inputLabelError : inputLabel}
+					hasError={inputHasError}
+				/>
+			</Modal>
+		</>
+	);
+};
+
+describe('Input', () => {
+	test('Input inside a Modal does not lose focus after typing first character', async () => {
+		render(<ModalWithInput />);
+		expect(screen.getByRole('button', { name: /open modal/i })).toBeVisible();
+		userEvent.click(screen.getByRole('button', { name: /open modal/i }));
+		await screen.findByText(/modal title/i);
+		const inputElement = screen.getByRole('textbox', { name: /input label/i });
+		expect(inputElement).toBeInTheDocument();
+		userEvent.click(inputElement);
+		await waitFor(() => expect(inputElement).toHaveFocus());
+		// type a character
+		await userEvent.type(inputElement, 'a', { delay: 10, skipClick: true });
+		expect(inputElement).toHaveValue('a');
+		expect(inputElement).toHaveFocus();
+	});
+});

--- a/src/components/inputs/Input.tsx
+++ b/src/components/inputs/Input.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React, { InputHTMLAttributes, useCallback, useMemo, useRef, useState } from 'react';
+import React, { InputHTMLAttributes, useCallback, useEffect, useMemo, useState } from 'react';
 import styled, { css, SimpleInterpolation } from 'styled-components';
 import { useCombinedRefs } from '../../hooks/useCombinedRefs';
 import { KeyboardPreset, useKeyboard } from '../../hooks/useKeyboard';
@@ -179,8 +179,7 @@ const Input: Input = React.forwardRef<HTMLDivElement, InputProps>(function Input
 	ref
 ) {
 	const [hasFocus, setHasFocus] = useState(false);
-	const innerRef = useRef<HTMLInputElement | null>(null);
-	const comboRef = useCombinedRefs<HTMLInputElement>(inputRef, innerRef);
+	const innerRef = useCombinedRefs<HTMLInputElement>(inputRef);
 	const [id] = useState(() => {
 		if (!Input._newId) {
 			Input._newId = 0;
@@ -190,13 +189,15 @@ const Input: Input = React.forwardRef<HTMLDivElement, InputProps>(function Input
 	});
 
 	const onInputFocus = useCallback(() => {
-		if (!disabled && comboRef && comboRef.current) {
+		if (!disabled && innerRef && innerRef.current) {
 			setHasFocus(true);
-			comboRef.current.focus();
+			innerRef.current.focus();
 		}
-	}, [setHasFocus, comboRef, disabled]);
+	}, [innerRef, disabled]);
 
-	const onInputBlur = useCallback(() => setHasFocus(false), [setHasFocus]);
+	const onInputBlur = useCallback(() => {
+		setHasFocus(false);
+	}, []);
 
 	const keyboardEvents = useMemo<KeyboardPreset>(() => {
 		const events: KeyboardPreset = [];
@@ -212,7 +213,7 @@ const Input: Input = React.forwardRef<HTMLDivElement, InputProps>(function Input
 		return events;
 	}, [onEnter]);
 
-	useKeyboard(comboRef, keyboardEvents);
+	useKeyboard(innerRef, keyboardEvents);
 
 	return (
 		<Container height="fit" width="fill" crossAlignment="flex-start">
@@ -234,7 +235,7 @@ const Input: Input = React.forwardRef<HTMLDivElement, InputProps>(function Input
 					autoFocus={autoFocus || undefined}
 					autoComplete={autoComplete || 'off'} // This one seems to be a React quirk, 'off' doesn't really work
 					color={textColor}
-					ref={comboRef}
+					ref={innerRef}
 					type={type}
 					onFocus={onInputFocus}
 					onBlur={onInputBlur}


### PR DESCRIPTION
Set the dependency to only windowObj instead of windowObj.document.activeElement
in order to avoid the hook to re-run each time the activeElement change.
This change was causing for modals a reset of the focused element to the modal itself,
making the input inside losing focus while typing.

refs: CDS-54