### PR TITLE
fix: emailComposerInput change callback param

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
 				"process": "0.11.10",
 				"react": "^17.0.2",
 				"react-dom": "^17.0.2",
-				"react-styleguidist": "^11.1.8",
+				"react-styleguidist": "^11.2.0",
 				"react-test-renderer": "17.0.2",
 				"rollup": "2.63.0",
 				"rollup-plugin-copy": "3.4.0",

--- a/src/components/inputs/EmailComposerInput.tsx
+++ b/src/components/inputs/EmailComposerInput.tsx
@@ -122,7 +122,7 @@ interface EmailComposerInputProps extends HTMLAttributes<HTMLDivElement> {
 	/** Input's value */
 	value?: string;
 	/** Callback to call when Input's value changes */
-	onChange?: () => void;
+	onChange?: (ev: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 const EmailComposerInput = React.forwardRef<HTMLDivElement, EmailComposerInputProps>(


### PR DESCRIPTION
Fix: added a param on the onChange callback declared in EmailComposerInputProps. The param receives the change event 