### PR TITLE
fix: chip content width when avatar is not shown

### DIFF
--- a/src/components/display/Chip.tsx
+++ b/src/components/display/Chip.tsx
@@ -385,9 +385,9 @@ const Chip = React.forwardRef<HTMLDivElement, ChipProps>(function ChipFn(
 					} / 4))`}
 					maxWidth={
 						maxWidth &&
-						`calc(100% - calc(${theme.sizes.avatar[SIZES[size].avatar].diameter} + ${
-							SIZES[size].spacing
-						}))`
+						`calc(100% - calc(${
+							hasAvatar ? theme.sizes.avatar[SIZES[size].avatar].diameter : 0
+						} + ${SIZES[size].spacing}))`
 					}
 					gap={SIZES[size].spacing}
 				>


### PR DESCRIPTION
Fix: when computing the _maxWidth_ of the content container the avatar width is also taken into account even when the avatar is not shown (_hasAvatar_ set to false). The result is a smaller width for the label and the _close_ action icon slightly shifted to the left