### PR TITLE
ci: fix npm release stage to only update tags

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -221,7 +221,7 @@ pipeline {
                     steps {
                         script {
                             executeNpmLogin()
-                            nodeCmd("NODE_ENV=\"production\" npm dist-tag add ${getPackageName()}@${getCurrentVersion()} latest && npm dist-tag rm ${getPackageName()}@${getCurrentVersion()} rc")
+                            nodeCmd("NODE_ENV=\"production\" npm dist-tag add ${getPackageName()}@${getCurrentVersion()} latest && npm dist-tag rm ${getPackageName()} rc")
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,10 @@ def getCommitParentsCount() {
     ''', returnStdout: true).trim()
 }
 
+def getPackageName() {
+    return sh(script: 'grep \'"name":\' package.json | sed -n --regexp-extended \'s/.*"name": "([^"]+).*/\\1/p\' ', returnStdout: true).trim()
+}
+
 def getCurrentVersion() {
     return sh(script: 'grep \'"version":\' package.json | sed -n --regexp-extended \'s/.*"version": "([^"]+).*/\\1/p\' ', returnStdout: true).trim()
 }
@@ -217,7 +221,7 @@ pipeline {
                     steps {
                         script {
                             executeNpmLogin()
-                            nodeCmd("NODE_ENV=\"production\" npm publish")
+                            nodeCmd("NODE_ENV=\"production\" npm dist-tag add ${getPackageName()}@${getCurrentVersion()} latest && npm dist-tag rm ${getPackageName()}@${getCurrentVersion()} rc")
                         }
                     }
                 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 	],
 	"author": "Zextras Frontend Tribe <https://www.zextras.com/carbonio/>",
 	"license": "AGPL-3.0-only",
-	"homepage": "https://bitbucket.org/zextras/zapp-ui#readme",
+	"homepage": "https://github.com/Zextras/carbonio-design-system",
 	"sideEffects": false,
 	"devDependencies": {
 		"@babel/core": "7.16.0",


### PR DESCRIPTION
Since the package version is already published with the rc tag,
the npm publish command throw an error.
The "release to npm" stage in the pipeline should only update the tags
in order to make the current version the "latest" version on npm