### PR TITLE
fix(Modal): avoid button text overflow

### DIFF
--- a/src/components/feedback/Modal.md
+++ b/src/components/feedback/Modal.md
@@ -21,12 +21,15 @@ const closeHandler = () => setOpen(false);
 
 <>
     <Button label="Trigger Modal" onClick={clickHandler}/>
-    <Modal
-        title="Title_bold_dark"
-        open={open}
-        onConfirm={closeHandler}
-        onClose={closeHandler}
-		showCloseIcon={true}
+		<Modal
+			optionalFooter={<Button label="opt footer"/>}
+			secondaryActionLabel="very long secondary label"
+			onSecondaryAction={() => {}}
+			title="Title_bold_dark"
+			open={open}
+			onConfirm={closeHandler}
+			onClose={closeHandler}
+			showCloseIcon={true}
 		>
         <Text overflow="break-word">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</Text>
     </Modal>

--- a/src/components/feedback/Modal.tsx
+++ b/src/components/feedback/Modal.tsx
@@ -25,6 +25,7 @@ import { Text } from '../basic/Text';
 import { IconButton } from '../inputs/IconButton';
 import { Container } from '../layout/Container';
 import { Divider } from '../layout/Divider';
+import { Padding } from '../layout/Padding';
 import { Row } from '../layout/Row';
 import { Portal } from '../utilities/Portal';
 import { Transition } from '../utilities/Transition';
@@ -92,10 +93,19 @@ const OptionalFooterContainer = styled(Container)`
 	flex-basis: auto;
 	flex-grow: 1;
 `;
-const ButtonContainer = styled(Container)`
+const ButtonContainer = styled(Container)<{ $pushLeftFirstChild?: boolean }>`
 	min-width: 1px;
 	flex-basis: auto;
 	flex-grow: 1;
+	${({ $pushLeftFirstChild }): SimpleInterpolation =>
+		$pushLeftFirstChild &&
+		css`
+			> * {
+				&:first-child {
+					margin-right: auto;
+				}
+			}
+		`}
 `;
 const DismissButton = styled(Button)`
 	margin-right: ${(props): string => props.theme.sizes.padding.large};
@@ -215,16 +225,22 @@ const ModalFooter: React.VFC<
 
 	return (
 		<>
-			{optionalFooter && (
+			{optionalFooter && centered && (
 				<OptionalFooterContainer
-					padding={centered ? { bottom: 'large' } : { right: 'large' }}
+					padding={{ bottom: 'large' }}
 					orientation="horizontal"
 					mainAlignment="flex-start"
 				>
 					{optionalFooter}
 				</OptionalFooterContainer>
 			)}
-			<ButtonContainer orientation="horizontal" mainAlignment={centered ? 'center' : 'flex-end'}>
+			<ButtonContainer
+				orientation="horizontal"
+				mainAlignment={centered ? 'center' : 'flex-end'}
+				$pushLeftFirstChild={optionalFooter != null && !centered}
+			>
+				{!centered && optionalFooter}
+				{!centered && <Padding right="large" />}
 				{secondaryButton}
 				{(onConfirm || onClose) && (
 					<ConfirmButton


### PR DESCRIPTION
avoid button text overflow, if is it possible, when optional Footer is provided

refs: CDS-64

before:
![Screenshot from 2022-09-13 16-16-03](https://user-images.githubusercontent.com/27196165/189925194-765dda58-a701-45bf-b11a-95650c74dcb4.png)


after:
![Screenshot from 2022-09-13 16-04-34](https://user-images.githubusercontent.com/27196165/189924069-b8af1498-e08f-4820-a490-d8214e9e817b.png)

