### PR TITLE
fix(ModalContent): remove default for min-height

### DIFF
--- a/src/components/feedback/modal-components/ModalComponents.tsx
+++ b/src/components/feedback/modal-components/ModalComponents.tsx
@@ -90,8 +90,7 @@ const ModalWrapper = styled.div`
 
 const ModalContent = styled(Container).attrs<{
 	$size: keyof typeof modalMinWidth & keyof typeof modalWidth;
-}>(({ minHeight = '250px', $size }) => ({
-	minHeight,
+}>(({ $size }) => ({
 	maxWidth: '100%',
 	minWidth: modalMinWidth[$size],
 	width: modalWidth[$size],


### PR DESCRIPTION
Remove default min height for modal content introduced with CDS-67

refs: CDS-94