### PR TITLE
feat: generate highlight set of theme from primary color set

### DIFF
--- a/docs/components/Palette.tsx
+++ b/docs/components/Palette.tsx
@@ -10,45 +10,47 @@ import styled from 'styled-components';
 
 import { Text } from '../../src/components/basic/Text';
 import { Container } from '../../src/components/layout/Container';
-import { Padding } from '../../src/components/layout/Padding';
+import { Row } from '../../src/components/layout/Row';
+import type { ThemeObj } from '../../src/theme/theme';
 
-const PaletteEl = styled.div`
-	width: 13.125rem;
+const PaletteEl = styled(Container)`
 	height: 6.25rem;
-	background: ${(props) => props.color};
 	border-radius: 0.5rem;
 	box-shadow: 0.375rem 0.25rem 0.625rem 0 rgba(136, 136, 136, 0.5);
 `;
-const TextFrame = styled.div`
-	background: rgba(200, 200, 200, 0.8);
-	padding: 0.25rem 0.5rem;
+const TextFrame = styled(Row)`
 	border-radius: 0.5rem 0.5rem 0 0;
 `;
 const ScrollFrame = styled.div`
 	width: 100%;
 	overflow-x: auto;
 `;
-const Palette = ({ palette }) => (
+const Palette = ({ palette }: ThemeObj): JSX.Element => (
 	<Container width="fill" height="fit" orientation="vertical" crossAlignment="flex-start">
 		{map(palette, (set, name) => (
 			<Fragment key={name}>
-				<Text size="large">{name}</Text>
+				<Text size="large" weight={'bold'}>
+					{name}
+				</Text>
 				<ScrollFrame>
 					<Container
 						orientation="horizontal"
 						height="fit"
-						width="fit"
+						width="fill"
 						padding={{ all: 'extrasmall', bottom: 'large' }}
-						mainAlignment="flex-start"
+						mainAlignment="stretch"
+						gap={'0.25rem'}
 					>
 						{map(set, (color, colorName) => (
-							<Padding horizontal="extrasmall" key={colorName}>
-								<PaletteEl name={name} color={color}>
-									<TextFrame>
-										<Text size="large">{`${colorName}: ${color}`}</Text>
-									</TextFrame>
-								</PaletteEl>
-							</Padding>
+							<PaletteEl key={colorName} background={color} mainAlignment={'flex-start'}>
+								<TextFrame
+									background={'rgba(200, 200, 200, 0.8)'}
+									padding={{ vertical: '0.25rem', horizontal: '0.5rem' }}
+									width={'fill'}
+								>
+									<Text size="extrasmall" overflow={'break-word'}>{`${colorName}: ${color}`}</Text>
+								</TextFrame>
+							</PaletteEl>
 						))}
 					</Container>
 				</ScrollFrame>

--- a/docs/default-theme.md
+++ b/docs/default-theme.md
@@ -8,9 +8,11 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 ```jsx noeditor
 import Palette from './components/Palette';
-import { Theme } from '../src/theme/theme';
+import { useTheme } from '@zextras/carbonio-design-system';
 
-<Palette palette={ Theme.palette }/>;
+const theme = useTheme();
+
+<Palette palette={theme.palette} />;
 
 ```
 
@@ -20,14 +22,14 @@ import { Theme } from '../src/theme/theme';
 
 ```jsx noeditor
 import { map } from 'lodash';
-import { Theme } from '../src/theme/theme';
-import { Text } from '../src/components/basic/Text';
-import { Container } from '../src/components/layout/Container';
+import { useTheme, Container, Text } from '@zextras/carbonio-design-system';
+
+const theme = useTheme();
 
 <Container orientation="vertical" padding={{ all: 'large' }}>
 	{
 		map(
-			Theme.sizes.font,
+			theme.sizes.font,
 			(size, key) => (
 				<Text key={key} size={key}>This text is {size}</Text>
 			)

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -10,7 +10,7 @@ The theme customization can be accomplished by providing a modifier function to 
 
 ```jsx
 import { useContext } from 'react';
-import { Text, Container, ThemeProvider, Button, generateColorSet } from '@zextras/carbonio-design-system';
+import { Text, Container, ThemeProvider, Button, generateColorSet, Row } from '@zextras/carbonio-design-system';
 import { map } from 'lodash';
 
 const editTheme = (theme) => ({
@@ -25,9 +25,11 @@ const editTheme = (theme) => ({
 });
 <ThemeProvider loadDefaultFont extension={editTheme}>
 		<Container background="additional" height={500}>
+          <Row background="highlight">
 			<Text>
 				Hello world
 			</Text>
+          </Row>
 			<Button label="Pink Button" />
 			<Button label="Green Button" backgroundColor="green" />
 		</Container>

--- a/lib/styleguide/Logo.tsx
+++ b/lib/styleguide/Logo.tsx
@@ -4,27 +4,31 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import React, { useEffect, useState, useMemo } from 'react';
+
 import { enable, disable, auto, isEnabled } from 'darkreader';
-import { Text } from '../../src/components/basic/Text';
+
 import { Button } from '../../src/components/basic/Button';
+import { Text } from '../../src/components/basic/Text';
 import { Container } from '../../src/components/layout/Container';
 import { Padding } from '../../src/components/layout/Padding';
 import { ThemeProvider } from '../../src/theme/theme-context-provider';
 
-const Logo = () => {
+const Logo = (): JSX.Element => {
 	const [mode, setMode] = useState('auto');
 
 	useEffect(() => {
 		switch (mode) {
 			case 'light':
+				auto(false);
 				disable();
 				break;
 			case 'dark':
+				auto(false);
 				enable({ sepia: -10 });
 				break;
 			case 'auto':
 			default:
-				auto();
+				auto({});
 				break;
 		}
 	}, [mode]);
@@ -65,7 +69,7 @@ const Logo = () => {
 					Style Guide
 				</Text>
 				<Padding top="medium">
-					<Button width="fill" icon={icon} onClick={() => setMode(next)} label="MODE" />
+					<Button width="fill" icon={icon} onClick={(): void => setMode(next)} label="MODE" />
 				</Padding>
 			</Container>
 		</ThemeProvider>

--- a/lib/styleguide/Wrapper.tsx
+++ b/lib/styleguide/Wrapper.tsx
@@ -4,8 +4,13 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import React from 'react';
+
 import { ThemeProvider } from '../../src/theme/theme-context-provider';
 
-export default function Wrapper({ children }) {
+export default function Wrapper({
+	children
+}: {
+	children?: React.ReactNode | React.ReactNode[];
+}): JSX.Element {
 	return <ThemeProvider>{children}</ThemeProvider>;
 }

--- a/src/theme/theme-context-provider.tsx
+++ b/src/theme/theme-context-provider.tsx
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React, { useMemo } from 'react';
+import React, { useCallback } from 'react';
 
 import { ThemeProvider as SCThemeProvider, ThemeContext, DefaultTheme } from 'styled-components';
 
 import DefaultFontStyles from './roboto-global-styles';
 import { Theme as defaultTheme } from './theme';
+import { generateHighlightSet } from './theme-utils';
 
 interface ThemeProviderProps {
 	extension?: (theme: DefaultTheme) => DefaultTheme;
@@ -17,7 +18,14 @@ interface ThemeProviderProps {
 }
 
 const ThemeProvider: React.FC<ThemeProviderProps> = ({ children, extension, loadDefaultFont }) => {
-	const _theme = useMemo(() => (extension ? extension(defaultTheme) : defaultTheme), [extension]);
+	const _theme = useCallback(
+		(parentTheme: DefaultTheme = defaultTheme) => {
+			const theme = extension ? extension(parentTheme) : parentTheme;
+			theme.palette.highlight = generateHighlightSet(theme.palette.primary);
+			return theme;
+		},
+		[extension]
+	);
 
 	return (
 		<SCThemeProvider theme={_theme}>

--- a/src/theme/theme-utils.test.ts
+++ b/src/theme/theme-utils.test.ts
@@ -4,144 +4,174 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { Theme } from './theme';
-import { getPadding } from './theme-utils';
+import type { ThemeColorObj } from './theme';
+import { generateHighlightSet, getPadding } from './theme-utils';
 
-describe('getPadding', () => {
-	describe('from string', () => {
-		test('with 1 css value', () => {
-			const initial = '0.625rem';
-			const result = getPadding(initial, Theme);
-			expect(result).toBe('0.625rem');
-		});
-
-		test('with 2 css values', () => {
-			const initial = '0.625rem 1.25rem';
-			const result = getPadding(initial, Theme);
-			expect(result).toBe('0.625rem 1.25rem');
-		});
-
-		test('with 3 css values', () => {
-			const initial = '0.625rem 1.25rem 1.875rem';
-			const result = getPadding(initial, Theme);
-			expect(result).toBe('0.625rem 1.25rem 1.875rem');
-		});
-
-		test('with 4 css values', () => {
-			const initial = '0.625rem 1.25rem 1.875rem 2.5rem';
-			const result = getPadding(initial, Theme);
-			expect(result).toBe('0.625rem 1.25rem 1.875rem 2.5rem');
-		});
-
-		test('with 1 theme key', () => {
-			const initial = 'extrasmall';
-			const result = getPadding(initial, Theme);
-			expect(result).toBe('0.25rem');
-		});
-
-		test('with 2 theme keys', () => {
-			const initial = 'extrasmall small';
-			const result = getPadding(initial, Theme);
-			expect(result).toBe('0.25rem 0.5rem');
-		});
-
-		test('with 3 theme keys', () => {
-			const initial = 'extrasmall small medium';
-			const result = getPadding(initial, Theme);
-			expect(result).toBe('0.25rem 0.5rem 0.75rem');
-		});
-
-		test('with 4 theme keys', () => {
-			const initial = 'extrasmall small medium large';
-			const result = getPadding(initial, Theme);
-			expect(result).toBe('0.25rem 0.5rem 0.75rem 1rem');
-		});
-
-		test('with mixed values and keys', () => {
-			const initial = 'extrasmall 1.25rem 1.875rem large';
-			const result = getPadding(initial, Theme);
-			expect(result).toBe('0.25rem 1.25rem 1.875rem 1rem');
-		});
-	});
-
-	describe('from object', () => {
-		describe('with value property', () => {
-			test('et as value', () => {
-				const initial = { value: '1rem' };
+describe('Theme Utils', () => {
+	describe('getPadding', () => {
+		describe('from string', () => {
+			test('with 1 css value', () => {
+				const initial = '0.625rem';
 				const result = getPadding(initial, Theme);
-				expect(result).toBe('1rem');
+				expect(result).toBe('0.625rem');
 			});
 
-			test('set as key', () => {
-				const initial = { value: 'extrasmall' };
+			test('with 2 css values', () => {
+				const initial = '0.625rem 1.25rem';
+				const result = getPadding(initial, Theme);
+				expect(result).toBe('0.625rem 1.25rem');
+			});
+
+			test('with 3 css values', () => {
+				const initial = '0.625rem 1.25rem 1.875rem';
+				const result = getPadding(initial, Theme);
+				expect(result).toBe('0.625rem 1.25rem 1.875rem');
+			});
+
+			test('with 4 css values', () => {
+				const initial = '0.625rem 1.25rem 1.875rem 2.5rem';
+				const result = getPadding(initial, Theme);
+				expect(result).toBe('0.625rem 1.25rem 1.875rem 2.5rem');
+			});
+
+			test('with 1 theme key', () => {
+				const initial = 'extrasmall';
 				const result = getPadding(initial, Theme);
 				expect(result).toBe('0.25rem');
 			});
 
-			test('set as mix of value and keys', () => {
-				const initial = { value: 'extrasmall 1rem extralarge' };
+			test('with 2 theme keys', () => {
+				const initial = 'extrasmall small';
 				const result = getPadding(initial, Theme);
-				expect(result).toBe('0.25rem 1rem 1.5rem');
-			});
-		});
-
-		describe('with all property', () => {
-			test('set as value', () => {
-				const initial = { all: '1rem' };
-				const result = getPadding(initial, Theme);
-				expect(result).toBe('1rem');
+				expect(result).toBe('0.25rem 0.5rem');
 			});
 
-			test('set as key', () => {
-				const initial = { all: 'extrasmall' };
+			test('with 3 theme keys', () => {
+				const initial = 'extrasmall small medium';
 				const result = getPadding(initial, Theme);
-				expect(result).toBe('0.25rem');
+				expect(result).toBe('0.25rem 0.5rem 0.75rem');
 			});
 
-			test('set as mix of value and keys', () => {
-				const initial = { all: 'extrasmall 1rem extralarge' };
-				const result = getPadding(initial, Theme);
-				expect(result).toBe('0.25rem 1rem 1.5rem');
-			});
-		});
-
-		describe('with vertical and horizontal properties', () => {
-			test('set as value', () => {
-				const initial = { vertical: '1rem' };
-				const result = getPadding(initial, Theme);
-				expect(result).toBe('1rem 0 1rem 0');
-			});
-
-			test('set as key', () => {
-				const initial = { horizontal: 'extrasmall' };
-				const result = getPadding(initial, Theme);
-				expect(result).toBe('0 0.25rem 0 0.25rem');
-			});
-
-			test('set as mix of value and keys', () => {
-				const initial = { vertical: 'extrasmall', horizontal: '1rem' };
-				const result = getPadding(initial, Theme);
-				expect(result).toBe('0.25rem 1rem 0.25rem 1rem');
-			});
-		});
-
-		describe('with top, right, bottom, left properties', () => {
-			test('set as value', () => {
-				const initial = { top: '1rem' };
-				const result = getPadding(initial, Theme);
-				expect(result).toBe('1rem 0 0 0');
-			});
-
-			test('set as key', () => {
-				const initial = { top: 'extrasmall', right: 'small', bottom: 'medium', left: 'large' };
+			test('with 4 theme keys', () => {
+				const initial = 'extrasmall small medium large';
 				const result = getPadding(initial, Theme);
 				expect(result).toBe('0.25rem 0.5rem 0.75rem 1rem');
 			});
 
-			test('set as mix of value and keys', () => {
-				const initial = { bottom: 'extrasmall', left: '1rem' };
+			test('with mixed values and keys', () => {
+				const initial = 'extrasmall 1.25rem 1.875rem large';
 				const result = getPadding(initial, Theme);
-				expect(result).toBe('0 0 0.25rem 1rem');
+				expect(result).toBe('0.25rem 1.25rem 1.875rem 1rem');
 			});
+		});
+
+		describe('from object', () => {
+			describe('with value property', () => {
+				test('et as value', () => {
+					const initial = { value: '1rem' };
+					const result = getPadding(initial, Theme);
+					expect(result).toBe('1rem');
+				});
+
+				test('set as key', () => {
+					const initial = { value: 'extrasmall' };
+					const result = getPadding(initial, Theme);
+					expect(result).toBe('0.25rem');
+				});
+
+				test('set as mix of value and keys', () => {
+					const initial = { value: 'extrasmall 1rem extralarge' };
+					const result = getPadding(initial, Theme);
+					expect(result).toBe('0.25rem 1rem 1.5rem');
+				});
+			});
+
+			describe('with all property', () => {
+				test('set as value', () => {
+					const initial = { all: '1rem' };
+					const result = getPadding(initial, Theme);
+					expect(result).toBe('1rem');
+				});
+
+				test('set as key', () => {
+					const initial = { all: 'extrasmall' };
+					const result = getPadding(initial, Theme);
+					expect(result).toBe('0.25rem');
+				});
+
+				test('set as mix of value and keys', () => {
+					const initial = { all: 'extrasmall 1rem extralarge' };
+					const result = getPadding(initial, Theme);
+					expect(result).toBe('0.25rem 1rem 1.5rem');
+				});
+			});
+
+			describe('with vertical and horizontal properties', () => {
+				test('set as value', () => {
+					const initial = { vertical: '1rem' };
+					const result = getPadding(initial, Theme);
+					expect(result).toBe('1rem 0 1rem 0');
+				});
+
+				test('set as key', () => {
+					const initial = { horizontal: 'extrasmall' };
+					const result = getPadding(initial, Theme);
+					expect(result).toBe('0 0.25rem 0 0.25rem');
+				});
+
+				test('set as mix of value and keys', () => {
+					const initial = { vertical: 'extrasmall', horizontal: '1rem' };
+					const result = getPadding(initial, Theme);
+					expect(result).toBe('0.25rem 1rem 0.25rem 1rem');
+				});
+			});
+
+			describe('with top, right, bottom, left properties', () => {
+				test('set as value', () => {
+					const initial = { top: '1rem' };
+					const result = getPadding(initial, Theme);
+					expect(result).toBe('1rem 0 0 0');
+				});
+
+				test('set as key', () => {
+					const initial = { top: 'extrasmall', right: 'small', bottom: 'medium', left: 'large' };
+					const result = getPadding(initial, Theme);
+					expect(result).toBe('0.25rem 0.5rem 0.75rem 1rem');
+				});
+
+				test('set as mix of value and keys', () => {
+					const initial = { bottom: 'extrasmall', left: '1rem' };
+					const result = getPadding(initial, Theme);
+					expect(result).toBe('0 0 0.25rem 1rem');
+				});
+			});
+		});
+	});
+
+	describe('generate highlight color set', () => {
+		test('transform a partial set in a complete set', () => {
+			const from = { regular: '#2b73d2' };
+			const expected = {
+				regular: expect.stringMatching(/#\w{6}/),
+				hover: expect.stringMatching(/#\w{6}/),
+				active: expect.stringMatching(/#\w{6}/),
+				focus: expect.stringMatching(/#\w{6}/),
+				disabled: expect.stringMatching(/#\w{6}/)
+			};
+
+			const result = generateHighlightSet(from);
+			expect(result).toEqual<ThemeColorObj>(expect.objectContaining(expected));
+		});
+
+		test('transform the regular value applying the the rule H = H + 1, S = S - 1, L = Min(L + 40, 90)', () => {
+			const from = ['#2B73D2', '#E60000', '#DA1D52', '#542D84', '#FCB136'];
+			const expected = ['#D5E3F6', '#FFB4B3', '#F8C9D6', '#BDA1DE', '#FEECCD'];
+			expect(from.length).toBe(expected.length);
+			from.forEach((fromColor, index) => {
+				const result = generateHighlightSet({ regular: fromColor });
+				expect(result.regular.toUpperCase()).toBe(expected[index].toUpperCase());
+			});
+			expect.assertions(from.length + 1);
 		});
 	});
 });

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -155,11 +155,11 @@ export const Theme: ThemeObj = {
 			disabled: '#cfd5dc'
 		},
 		highlight: {
-			regular: '#d5e3f6',
-			hover: '#abc7ed',
-			active: '#96b8e8',
-			focus: '#abc7ed',
-			disabled: '#d5e3f6'
+			regular: '', // will be calculated programmatically
+			hover: '', // will be calculated programmatically
+			active: '', // will be calculated programmatically
+			focus: '', // will be calculated programmatically
+			disabled: '' // will be calculated programmatically
 		},
 		gray0: {
 			regular: '#414141',


### PR DESCRIPTION
Use new algorithm to calculate highlight from primary color set.

Use theme function to set theme in StyledComponent provider in order
to allow nesting of multiple providers, with parent theme passed as arg of children providers.

refs: CDS-109