### PR TITLE
fix(Button)!: change ref destination element

### DIFF
--- a/src/components/basic/Button.test.tsx
+++ b/src/components/basic/Button.test.tsx
@@ -7,10 +7,11 @@
 import React from 'react';
 
 import { faker } from '@faker-js/faker';
-import { screen, act } from '@testing-library/react';
+import { screen, act, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { render } from '../../test-utils';
+import { Tooltip } from '../display/Tooltip';
 import { Button } from './Button';
 
 describe('Button', () => {
@@ -69,5 +70,29 @@ describe('Button', () => {
 		expect(screen.getByText(new RegExp(label, 'i'))).not.toBeVisible();
 		expect(screen.getByTestId('spinner')).toBeInTheDocument();
 		expect(screen.getByTestId('spinner')).toBeVisible();
+	});
+
+	test('Show tooltip on disabled button', async () => {
+		const clickFn = jest.fn();
+		render(
+			<Tooltip label={'Tooltip label'}>
+				<Button label={'Button'} loading onClick={clickFn} disabled />
+			</Tooltip>
+		);
+		// FIXME: hover event on disabled button is not bubbled up. Remove access on parentElement when possible
+		const button = screen.getByRole('button').parentElement as HTMLElement;
+		// wait for tooltip to register listeners
+		await waitFor(
+			() =>
+				new Promise((resolve) => {
+					setTimeout(resolve, 2);
+				})
+		);
+		expect(screen.queryByText('Tooltip label')).not.toBeInTheDocument();
+		userEvent.hover(button);
+		await screen.findByText('Tooltip label');
+		expect(screen.getByText('Tooltip label')).toBeVisible();
+		userEvent.unhover(button);
+		expect(screen.queryByText('Tooltip label')).not.toBeInTheDocument();
 	});
 });

--- a/src/components/basic/Button.tsx
+++ b/src/components/basic/Button.tsx
@@ -75,6 +75,8 @@ type ButtonPropsInternal = {
 	width?: ButtonWidth;
 	/** min width of the button */
 	minWidth?: string;
+	/** Ref for the button element */
+	buttonRef?: React.Ref<HTMLButtonElement> | null;
 } & (
 	| {
 			/** Size variant of the button */
@@ -330,7 +332,7 @@ function getColors(
 	return colors;
 }
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function ButtonFn(
+const Button = React.forwardRef<HTMLDivElement, ButtonProps>(function ButtonFn(
 	{
 		type = 'default',
 		disabled = false,
@@ -345,11 +347,12 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function ButtonF
 		shape = 'regular',
 		secondaryAction,
 		minWidth,
+		buttonRef = null,
 		...rest
 	},
 	ref
 ) {
-	const buttonRef = useCombinedRefs<HTMLButtonElement>(ref);
+	const innerButtonRef = useCombinedRefs<HTMLButtonElement>(buttonRef);
 
 	const clickHandler = useCallback(
 		(e: KeyboardEvent | React.MouseEvent<HTMLButtonElement>) => {
@@ -371,12 +374,12 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function ButtonF
 	);
 
 	const keyEvents = useMemo(() => getKeyboardPreset('button', clickHandler), [clickHandler]);
-	useKeyboard(buttonRef, keyEvents);
+	useKeyboard(innerButtonRef, keyEvents);
 
 	const colors = useMemo(() => getColors(type, { type, ...rest }), [type, rest]);
 
 	return (
-		<StyledGrid width={width} minWidth={minWidth} padding={SIZES[size].padding}>
+		<StyledGrid width={width} minWidth={minWidth} padding={SIZES[size].padding} ref={ref}>
 			<StyledButton
 				{...rest}
 				backgroundColor={colors.backgroundColor}
@@ -389,7 +392,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function ButtonF
 				gap={SIZES[size].gap}
 				iconPlacement={iconPlacement}
 				onClick={clickHandler}
-				ref={buttonRef}
+				ref={innerButtonRef}
 				width={width}
 				minWidth={minWidth}
 			>

--- a/src/components/display/Popover.test.tsx
+++ b/src/components/display/Popover.test.tsx
@@ -17,7 +17,7 @@ import { Popover } from './Popover';
 
 const CustomPopover = (): JSX.Element => {
 	const [open, setOpen] = useState(false);
-	const buttonRef = useRef<HTMLButtonElement>(null);
+	const buttonRef = useRef<HTMLDivElement>(null);
 	return (
 		<>
 			<Button

--- a/src/components/inputs/FileLoader.tsx
+++ b/src/components/inputs/FileLoader.tsx
@@ -26,7 +26,7 @@ type FileLoaderProps = IconButtonProps & {
 	accept?: string;
 };
 
-const FileLoader = React.forwardRef<HTMLButtonElement, FileLoaderProps>(function FileLoaderFn(
+const FileLoader = React.forwardRef<HTMLDivElement, FileLoaderProps>(function FileLoaderFn(
 	{ icon = 'Attach', onChange = (): void => undefined, multiple = false, accept, ...rest },
 	ref
 ) {

--- a/src/components/inputs/IconButton.tsx
+++ b/src/components/inputs/IconButton.tsx
@@ -63,7 +63,7 @@ type IconButtonProps = ButtonProps & {
 	secondaryAction?: never;
 };
 
-const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(function IconButtonFn(
+const IconButton = React.forwardRef<HTMLDivElement, IconButtonProps>(function IconButtonFn(
 	{
 		iconColor = 'text',
 		backgroundColor = 'transparent',
@@ -79,7 +79,7 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(function
 	},
 	ref
 ) {
-	const iconButtonRef = useCombinedRefs<HTMLButtonElement>(ref);
+	const iconButtonRef = useCombinedRefs<HTMLDivElement>(ref);
 	const theme = useTheme();
 
 	const { iconSize, paddingSize } = useMemo(


### PR DESCRIPTION
Assign main ref of the Button component to the external grid.
Add a buttonRef prop for the ref of the button element.
Update ref type declaration also on other components which use a button.
Add test for Tooltip on disabled Button.

This change affect only those situations where a ref has been used to register specific listeners or where the Button has been wrapped in a styled component.
In the first case, just rename the ref prop passed to the button to buttonRef.
In the second case, depending on the styled applied, it might be necessary to update the css selector in order to make it specific to the inner button element.
Where none of these cases apply, no change is required.

BREAKING CHANGE: set main ref to external grid container and add buttonRef prop to receive the ref for the main button element, in order to make events fire also on disabled element if registered on the main ref.
refs: CDS-82