### PR TITLE
feat(TextArea): create TextArea component

### DIFF
--- a/src/components/inputs/ChipInput.tsx
+++ b/src/components/inputs/ChipInput.tsx
@@ -22,11 +22,12 @@ import { useKeyboard, getKeyboardPreset, KeyboardPreset } from '../../hooks/useK
 import { usePrevious } from '../../hooks/usePrevious';
 import { getColor, pseudoClasses } from '../../theme/theme-utils';
 import { Icon } from '../basic/Icon';
-import { Text, TextProps } from '../basic/Text';
 import { Chip, ChipProps } from '../display/Chip';
 import { Dropdown, DropdownItem } from '../display/Dropdown';
 import { Container, ContainerProps } from '../layout/Container';
 import { Divider, DividerProps } from '../layout/Divider';
+import { InputDescription } from './commons/InputDescription';
+import { InputLabel } from './commons/InputLabel';
 import { IconButton } from './IconButton';
 
 const ContainerEl = styled(Container)<{
@@ -184,44 +185,17 @@ const AdjustWidthInput = React.forwardRef<
 	);
 });
 
-const Label = styled.label<{
-	hasError: boolean;
-	hasFocus: boolean;
-	disabled: boolean;
-	hasItems: boolean;
+const Label = styled(InputLabel)<{
+	$hasItems: boolean;
 }>`
-	position: absolute;
-	top: 50%;
-	left: 0.75rem;
-	font-size: ${({ theme }): string => theme.sizes.font.medium};
-	font-weight: ${({ theme }): number => theme.fonts.weight.regular};
-	font-family: ${({ theme }): string => theme.fonts.default};
-	line-height: 1.5;
-	color: ${({ theme, hasError, hasFocus, disabled }): string =>
-		getColor(
-			`${(hasError && 'error') || (hasFocus && 'primary') || 'secondary'}.${
-				disabled ? 'disabled' : 'regular'
-			}`,
-			theme
-		)};
-	transform: translateY(-50%);
-	transition: transform 150ms ease-out, font-size 150ms ease-out, top 150ms ease-out,
-		left 150ms ease-out;
-	pointer-events: none;
-	user-select: none;
-	max-width: calc(100% - ${({ theme }): string => `${theme.sizes.padding.large} * 2`});
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-
 	${InputContainer}:focus-within + & {
 		top: 0.0625rem;
 		transform: translateY(0);
 		font-size: ${({ theme }): string => theme.sizes.font.extrasmall};
 	}
 
-	${({ hasItems, theme }): SimpleInterpolation =>
-		hasItems &&
+	${({ $hasItems, theme }): SimpleInterpolation =>
+		$hasItems &&
 		css`
 			top: 0.0625rem;
 			transform: translateY(0);
@@ -233,19 +207,9 @@ const CustomIconContainer = styled.span`
 	align-self: center;
 `;
 
-const DividerEl = styled(Divider)`
-	&:disabled {
-		color: ${({ theme, color }): string => getColor(`${color}.disabled`, theme)};
-	}
-`;
-
-const CustomText = styled(Text)<{
+const CustomInputDescription = styled(InputDescription)<{
 	$backgroundColor?: string;
-	size: NonNullable<TextProps['size']>;
 }>`
-	line-height: 1.5;
-	padding-top: 0.25rem;
-	min-height: calc(${({ theme, size }): string => theme.sizes.font[size]} * 1.5);
 	background-color: ${({ $backgroundColor, theme }): string | undefined =>
 		$backgroundColor && getColor($backgroundColor, theme)};
 `;
@@ -729,6 +693,17 @@ const ChipInput: ChipInput = React.forwardRef<HTMLDivElement, ChipInputProps>(fu
 
 	const ChipComp = useMemo(() => ChipComponent || Chip, [ChipComponent]);
 
+	const dividerColor = useMemo<DividerProps['color']>(
+		() =>
+			`${
+				(hideBorder && 'transparent') ||
+				(hasError && 'error') ||
+				(hasFocus && 'primary') ||
+				bottomBorderColor
+			}${disabled ? '.disabled' : ''}`,
+		[bottomBorderColor, disabled, hasError, hasFocus, hideBorder]
+	);
+
 	return (
 		<Container height="fit" width="fill" crossAlignment="flex-start">
 			<Dropdown
@@ -791,10 +766,10 @@ const ChipInput: ChipInput = React.forwardRef<HTMLDivElement, ChipInputProps>(fu
 						{placeholder && (
 							<Label
 								htmlFor={id}
-								hasFocus={hasFocus}
-								hasError={hasError}
-								disabled={disabled && dropdownDisabled && (!iconAction || iconDisabled)}
-								hasItems={items.length > 0 || !!inputElRef.current?.value}
+								$hasFocus={hasFocus}
+								$hasError={hasError}
+								$disabled={disabled && dropdownDisabled && (!iconAction || iconDisabled)}
+								$hasItems={items.length > 0 || !!inputElRef.current?.value}
 							>
 								{placeholder}
 							</Label>
@@ -813,24 +788,15 @@ const ChipInput: ChipInput = React.forwardRef<HTMLDivElement, ChipInputProps>(fu
 					)}
 				</ContainerEl>
 			</Dropdown>
-			<DividerEl
-				color={
-					(hideBorder && 'transparent') ||
-					(hasError && 'error') ||
-					(hasFocus && 'primary') ||
-					bottomBorderColor
-				}
-			/>
+			<Divider color={dividerColor} />
 			{((hasError && errorLabel !== undefined) || description !== undefined) && (
-				<CustomText
-					size="extrasmall"
+				<CustomInputDescription
 					color={(hasError && 'error') || (hasFocus && 'primary') || 'secondary'}
 					disabled={disabled && dropdownDisabled && (!iconAction || iconDisabled)}
-					overflow="break-word"
 					$backgroundColor={errorBackgroundColor}
 				>
 					{(hasError && errorLabel) || description}
-				</CustomText>
+				</CustomInputDescription>
 			)}
 		</Container>
 	);

--- a/src/components/inputs/Input.tsx
+++ b/src/components/inputs/Input.tsx
@@ -6,37 +6,16 @@
 
 import React, { InputHTMLAttributes, useCallback, useMemo, useState } from 'react';
 
-import styled, { css, DefaultTheme, SimpleInterpolation } from 'styled-components';
+import styled, { DefaultTheme } from 'styled-components';
 
 import { useCombinedRefs } from '../../hooks/useCombinedRefs';
 import { KeyboardPreset, useKeyboard } from '../../hooks/useKeyboard';
-import { getColor, pseudoClasses } from '../../theme/theme-utils';
-import { Text, TextProps } from '../basic/Text';
+import { getColor } from '../../theme/theme-utils';
 import { Container } from '../layout/Container';
-import { Divider } from '../layout/Divider';
-
-const ContainerEl = styled(Container)<{
-	background: keyof DefaultTheme['palette'];
-	$disabled: boolean;
-	$hasLabel: boolean;
-}>`
-	position: relative;
-	${({ $disabled, background, theme }): SimpleInterpolation =>
-		$disabled
-			? css`
-					background: ${getColor(`${background}.disabled`, theme)};
-			  `
-			: css`
-					cursor: text;
-					${pseudoClasses(theme, background)}
-			  `};
-	padding: ${({ $hasLabel }): string => ($hasLabel ? '0.0625rem' : '0.625rem')} 0.75rem;
-	gap: 0.5rem;
-	min-height: calc(
-		${({ theme }): string => theme.sizes.font.medium} * 1.5 +
-			${({ theme }): string => theme.sizes.font.extrasmall} * 1.5 + 0.125rem
-	);
-`;
+import { Divider, DividerProps } from '../layout/Divider';
+import { InputContainer } from './commons/InputContainer';
+import { InputDescription } from './commons/InputDescription';
+import { InputLabel } from './commons/InputLabel';
 
 const InputEl = styled.input<{ color: keyof DefaultTheme['palette'] }>`
 	border: none !important;
@@ -63,31 +42,7 @@ const InputEl = styled.input<{ color: keyof DefaultTheme['palette'] }>`
 	}
 `;
 
-const Label = styled.label<{ hasError: boolean; hasFocus: boolean; disabled: boolean }>`
-	position: absolute;
-	top: 50%;
-	left: 0.75rem;
-	font-size: ${({ theme }): string => theme.sizes.font.medium};
-	font-weight: ${({ theme }): number => theme.fonts.weight.regular};
-	font-family: ${({ theme }): string => theme.fonts.default};
-	line-height: 1.5;
-	color: ${({ theme, hasError, hasFocus, disabled }): string =>
-		getColor(
-			`${(hasError && 'error') || (hasFocus && 'primary') || 'secondary'}.${
-				disabled ? 'disabled' : 'regular'
-			}`,
-			theme
-		)};
-	transform: translateY(-50%);
-	transition: transform 150ms ease-out, font-size 150ms ease-out, top 150ms ease-out,
-		left 150ms ease-out;
-	pointer-events: none;
-	user-select: none;
-	max-width: calc(100% - ${({ theme }): string => `${theme.sizes.padding.large} * 2`});
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-
+const Label = styled(InputLabel)`
 	${InputEl}:focus + &,
   ${InputEl}:not(:placeholder-shown) + & {
 		top: 0.0625rem;
@@ -98,18 +53,6 @@ const Label = styled.label<{ hasError: boolean; hasFocus: boolean; disabled: boo
 
 const CustomIconContainer = styled.span`
 	align-self: center;
-`;
-
-const DividerEl = styled(Divider)`
-	&:disabled {
-		color: ${({ theme, color }): string => getColor(`${color}.disabled`, theme)};
-	}
-`;
-
-const CustomText = styled(Text)<{ size: NonNullable<TextProps['size']> }>`
-	line-height: 1.5;
-	padding-top: 0.25rem;
-	min-height: calc(${({ theme, size }): string => theme.sizes.font[size]} * 1.5);
 `;
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
@@ -216,9 +159,20 @@ const Input: Input = React.forwardRef<HTMLDivElement, InputProps>(function Input
 
 	useKeyboard(innerRef, keyboardEvents);
 
+	const dividerColor = useMemo<DividerProps['color']>(
+		() =>
+			`${
+				(hideBorder && 'transparent') ||
+				(hasError && 'error') ||
+				(hasFocus && 'primary') ||
+				borderColor
+			}${disabled ? '.disabled' : ''}`,
+		[borderColor, disabled, hasError, hasFocus, hideBorder]
+	);
+
 	return (
 		<Container height="fit" width="fill" crossAlignment="flex-start">
-			<ContainerEl
+			<InputContainer
 				ref={ref}
 				orientation="horizontal"
 				width="fill"
@@ -249,7 +203,7 @@ const Input: Input = React.forwardRef<HTMLDivElement, InputProps>(function Input
 					placeholder={label}
 				/>
 				{label && (
-					<Label htmlFor={id} hasFocus={hasFocus} hasError={hasError} disabled={disabled}>
+					<Label htmlFor={id} $hasFocus={hasFocus} $hasError={hasError} $disabled={disabled}>
 						{label}
 					</Label>
 				)}
@@ -258,24 +212,15 @@ const Input: Input = React.forwardRef<HTMLDivElement, InputProps>(function Input
 						<CustomIcon hasError={hasError} hasFocus={hasFocus} disabled={disabled} />
 					</CustomIconContainer>
 				)}
-			</ContainerEl>
-			<DividerEl
-				color={
-					(hideBorder && 'transparent') ||
-					(hasError && 'error') ||
-					(hasFocus && 'primary') ||
-					borderColor
-				}
-			/>
+			</InputContainer>
+			<Divider color={dividerColor} />
 			{description !== undefined && (
-				<CustomText
-					size="extrasmall"
+				<InputDescription
 					color={(hasError && 'error') || (hasFocus && 'primary') || 'secondary'}
 					disabled={disabled}
-					overflow="break-word"
 				>
 					{description}
-				</CustomText>
+				</InputDescription>
 			)}
 		</Container>
 	);

--- a/src/components/inputs/TextArea.md
+++ b/src/components/inputs/TextArea.md
@@ -1,0 +1,131 @@
+TextArea is an HTML textarea element with some styled applied to make it totally similar to the Input component,
+but with the prerogative of the multiline.
+All attributes of the HTML textarea are available as props for the TextArea component.
+
+Through the maxHeight prop is possible to set the height limit, beyond which the scroll is activated.
+
+### UI Kit
+[TextArea Figma UI kit](https://www.figma.com/file/crORWeAU5S8Xugs4OmqPEV/UI-kit?node-id=1242%3A24185&t=MoazwV8SjJJTJ9qG-4)
+
+### Examples
+#### Default
+```jsx
+  <TextArea />
+```
+
+#### With label and description
+```jsx
+  import { faker } from '@faker-js/faker';
+  import { Container } from '@zextras/carbonio-design-system';
+
+  const loremIpsum = faker.lorem.paragraphs(4);
+  <Container gap={'0.5rem'} crossAlignment={'flex-start'}>
+    <TextArea label={'Label for the textarea'} />
+    <TextArea description={'Description to describe what is this textarea meant for'} />
+    <TextArea label={'Label for the textarea'} description={'Description to describe what is this textarea meant for'} defaultValue={loremIpsum} />
+  </Container>
+```
+
+#### Uncontrolled
+```jsx
+  import { useRef } from 'react';
+  import { Container } from '@zextras/carbonio-design-system';
+
+  const printContentPRef = useRef(null);
+
+  const onInput = (event) => {
+    if (printContentPRef.current) {
+        printContentPRef.current.textContent = event.currentTarget.value;
+    }
+  };
+
+  <Container gap={'0.5rem'} crossAlignment={'flex-start'}>
+    <TextArea
+        label={'Label for the textarea'}
+        description={'Description to describe what is this textarea meant for'}
+        defaultValue={'Default value for the text area'}
+        onInput={onInput}
+    />
+    <p ref={printContentPRef} style={{ border: '1px solid gray', width: '100%', minHeight: '1.5rem' }}>Type something</p>
+  </Container>
+```
+
+#### Controlled
+```jsx
+  import { useState } from 'react';
+  import { Container } from '@zextras/carbonio-design-system';
+
+  const [textAreaValue, setTextAreaValue] = useState('');
+
+  const onChange = (event) => {
+      setTextAreaValue(event.currentTarget.value);
+  };
+
+  <Container gap={'0.5rem'} crossAlignment={'flex-start'}>
+    <TextArea
+        label={'Label for the textarea'}
+        description={'Description to describe what is this textarea meant for'}
+        value={textAreaValue}
+        onChange={onChange}
+    />
+    <p style={{ border: '1px solid gray', width: '100%', minHeight: '1.5rem' }}>{textAreaValue || 'Type something'}</p>
+  </Container>
+```
+
+#### Disabled
+```jsx
+  import { faker } from '@faker-js/faker';
+  import { Container, Text } from '@zextras/carbonio-design-system';
+
+  const loremIpsum = faker.lorem.paragraphs(4);
+  
+  <Container gap={'0.5rem'} crossAlignment={'flex-start'}>
+    <Text weight={'bold'}>Without value</Text>
+    <TextArea
+        label={'Label for the textarea'}
+        description={'Description to describe what is this textarea meant for'}
+        disabled
+    />
+    <Text weight={'bold'}>With default value</Text>
+    <TextArea
+        label={'Label for the textarea'}
+        description={'Description to describe what is this textarea meant for'}
+        defaultValue={loremIpsum}
+        disabled
+    />
+    <Text weight={'bold'}>With value</Text>
+    <TextArea
+        label={'Label for the textarea'}
+        description={'Description to describe what is this textarea meant for'}
+        value={loremIpsum}
+        disabled
+    />
+  </Container>
+```
+
+#### With error
+```jsx
+  import { Container, Text } from '@zextras/carbonio-design-system';
+  
+  <Container gap={'0.5rem'} crossAlignment={'flex-start'}>
+    <TextArea hasError />
+    <TextArea
+        label={'Label for the textarea'}
+        description={'Description to describe what is this textarea meant for'}
+        hasError
+    />
+    <TextArea
+        label={'Label for the textarea'}
+        description={'Description to describe what is this textarea meant for'}
+        defaultValue={'It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of '}
+        hasError
+    />
+    <TextArea
+        label={'Label for the textarea'}
+        description={'Description to describe what is this textarea meant for'}
+        defaultValue={'It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of '}
+        hasError
+        disabled
+    />
+  </Container>
+```

--- a/src/components/inputs/TextArea.test.tsx
+++ b/src/components/inputs/TextArea.test.tsx
@@ -1,0 +1,157 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React from 'react';
+
+import { faker } from '@faker-js/faker';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { render } from '../../test-utils';
+import { Theme } from '../../theme/theme';
+import { TextArea } from './TextArea';
+
+describe('TextArea', () => {
+	test('Render an empty text area', () => {
+		render(<TextArea />);
+		expect(screen.getByRole('textbox')).toBeInTheDocument();
+		expect(screen.getByRole('textbox')).toBeVisible();
+	});
+
+	test('Render a text area with a label. Placeholder is set same as the label', () => {
+		render(<TextArea label={'A label'} />);
+		expect(screen.getByRole('textbox', { name: 'A label' })).toBeVisible();
+		expect(screen.getByRole('textbox')).toHaveAttribute('placeholder', 'A label');
+		expect(screen.getByText('A label')).toBeVisible();
+	});
+
+	test('Render a text area with a label and a different hidden placeholder', () => {
+		render(<TextArea label={'A label'} placeholder={'The placeholder'} />);
+		// name is the accessible name -> the label associated to the element
+		expect(screen.getByRole('textbox', { name: 'A label' })).toBeVisible();
+		expect(screen.getByRole('textbox')).toHaveAttribute('placeholder', 'The placeholder');
+		expect(screen.getByText('A label')).toBeVisible();
+		expect(screen.queryByText('The placeholder')).not.toBeInTheDocument();
+	});
+
+	test('Render a text area with a description', () => {
+		render(<TextArea label={'A label'} description={'Description for the textarea'} />);
+		expect(screen.getByRole('textbox', { name: 'A label' })).toBeVisible();
+		expect(screen.getByText('A label')).toBeVisible();
+		expect(screen.getByText('Description for the textarea')).toBeVisible();
+	});
+
+	test('Click on the label sets focus on the textarea', async () => {
+		render(<TextArea label={'A label'} description={'Description for the textarea'} />);
+		userEvent.click(screen.getByText('A label'));
+		expect(screen.getByRole('textbox')).toHaveFocus();
+	});
+
+	test('Click on the label does not set focus on the textarea if disabled', async () => {
+		render(<TextArea label={'A label'} description={'Description for the textarea'} disabled />);
+		userEvent.click(screen.getByText('A label'));
+		expect(screen.getByRole('textbox')).not.toHaveFocus();
+	});
+
+	test('Render a text are with a default value', () => {
+		const value = faker.lorem.lines();
+		render(<TextArea defaultValue={value} />);
+		expect(screen.getByRole('textbox')).toHaveValue(value);
+	});
+
+	test('onFocus is called when textarea get focus', async () => {
+		const onFocus = jest.fn();
+		render(<TextArea onFocus={onFocus} label={'The label'} description={'The description'} />);
+		const label = screen.getByText('The label');
+		userEvent.click(label);
+		expect(onFocus).toHaveBeenCalledTimes(1);
+	});
+
+	test('onBlur is called when textarea lose focus', async () => {
+		const onBlur = jest.fn();
+		render(<TextArea onBlur={onBlur} label={'The label'} description={'The description'} />);
+		const label = screen.getByText('The label');
+		const description = screen.getByText('The description');
+		userEvent.click(label);
+		userEvent.click(description);
+		expect(onBlur).toHaveBeenCalledTimes(1);
+	});
+
+	test('Blur event remove focus from text area and reset color for label and description', async () => {
+		render(<TextArea label={'The label'} description={'The description'} />);
+		const textArea = screen.getByRole('textbox');
+		const label = screen.getByText('The label');
+		const description = screen.getByText('The description');
+		expect(label).toHaveStyle(`color: ${Theme.palette.secondary.regular}`);
+		userEvent.click(textArea);
+		expect(textArea).toHaveFocus();
+		expect(label).toHaveStyle(`color: ${Theme.palette.primary.regular}`);
+		userEvent.click(description);
+		expect(textArea).not.toHaveFocus();
+		expect(label).toHaveStyle(`color: ${Theme.palette.secondary.regular}`);
+	});
+
+	test('Multiple text areas take different ids', () => {
+		render(
+			<>
+				<TextArea />
+				<TextArea />
+				<TextArea />
+			</>
+		);
+		const textAreas = screen.getAllByRole('textbox');
+		expect(textAreas).toHaveLength(3);
+		expect(textAreas[0].id).not.toEqual(textAreas[1].id);
+		expect(textAreas[0].id).not.toEqual(textAreas[2].id);
+		expect(textAreas[1].id).not.toEqual(textAreas[2].id);
+	});
+
+	describe('Uncontrolled mode', () => {
+		test('User can type into the textarea', async () => {
+			render(<TextArea />);
+			const text = faker.lorem.lines();
+			const textArea = screen.getByRole('textbox');
+			userEvent.type(textArea, text);
+			expect(textArea).toHaveValue(text);
+		});
+
+		test('User cannot type into a disabled textarea', async () => {
+			render(<TextArea disabled />);
+			const text = faker.lorem.lines();
+			const textArea = screen.getByRole('textbox');
+			userEvent.type(textArea, text);
+			expect(textArea).not.toHaveValue(text);
+			expect(textArea).toHaveValue('');
+		});
+	});
+
+	describe('Controlled mode', () => {
+		test('Render a text are with a value', () => {
+			const value = faker.lorem.lines();
+			render(<TextArea value={value} />);
+			expect(screen.getByRole('textbox')).toHaveValue(value);
+		});
+
+		test('User can type into the textarea, onChange is called and value is not updated automatically', async () => {
+			const onChange = jest.fn();
+			render(<TextArea value={''} onChange={onChange} />);
+			const text = faker.lorem.lines();
+			const textArea = screen.getByRole('textbox');
+			userEvent.type(textArea, text);
+			expect(onChange).toHaveBeenCalled();
+			expect(textArea).toHaveValue('');
+		});
+
+		test('User cannot type into a disabled textarea', async () => {
+			const onChange = jest.fn();
+			render(<TextArea value={''} onChange={onChange} disabled />);
+			const text = faker.lorem.lines();
+			const textArea = screen.getByRole('textbox');
+			userEvent.type(textArea, text);
+			expect(onChange).not.toHaveBeenCalled();
+			expect(textArea).toHaveValue('');
+		});
+	});
+});

--- a/src/components/inputs/TextArea.tsx
+++ b/src/components/inputs/TextArea.tsx
@@ -1,0 +1,305 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React, {
+	TextareaHTMLAttributes,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState
+} from 'react';
+
+import styled, { css, DefaultTheme, SimpleInterpolation } from 'styled-components';
+
+import { useCombinedRefs } from '../../hooks/useCombinedRefs';
+import { getColor } from '../../theme/theme-utils';
+import { TextProps } from '../basic/Text';
+import { Container } from '../layout/Container';
+import { Divider, DividerProps } from '../layout/Divider';
+import { InputContainer } from './commons/InputContainer';
+import { InputDescription } from './commons/InputDescription';
+import { InputLabel } from './commons/InputLabel';
+
+type HTMLTextAreaProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+interface AdjustHeightTextAreaProps extends HTMLTextAreaProps {
+	hasLabel: boolean;
+	maxHeight?: string;
+	color: string;
+}
+
+interface TextAreaProps extends HTMLTextAreaProps {
+	/** Description - helper text */
+	description?: string;
+	/** Error state */
+	hasError?: boolean;
+	/** Ref for the textarea element */
+	textAreaRef?: React.Ref<HTMLTextAreaElement> | null;
+	/** Label for the textarea */
+	label?: string;
+	/** Background color for the textarea */
+	backgroundColor?: string | keyof DefaultTheme['palette'];
+	/** Color for the text */
+	textColor?: string;
+	/** Max height for the text area, limit beyond which the scroll is enabled */
+	maxHeight?: string;
+	/** Divider color */
+	borderColor?: string | keyof DefaultTheme['palette'];
+}
+
+type TextArea = ReturnType<typeof React.forwardRef<HTMLDivElement, TextAreaProps>> & {
+	_newId?: number;
+};
+
+const StyledTextArea = styled.textarea<{ $color: string }>`
+	resize: none;
+	width: 100%;
+	max-height: 100%;
+	overflow-y: hidden;
+	outline: none;
+	background: transparent;
+	font-size: ${({ theme }): string => theme.sizes.font.medium};
+	font-weight: ${({ theme }): number => theme.fonts.weight.regular};
+	font-family: ${({ theme }): string => theme.fonts.default};
+	line-height: 1.5;
+	border: none;
+	padding: 0;
+	margin: 0;
+
+	&:disabled {
+		color: ${({ theme, $color }): string => getColor(`${$color}.disabled`, theme)};
+	}
+
+	&::placeholder {
+		color: transparent;
+		font-size: 0;
+		user-select: none;
+	}
+`;
+
+const GrowContainer = styled.div<{ $hasLabel: boolean; $maxHeight?: string }>`
+	width: 100%;
+	height: auto;
+	margin-top: ${({ $hasLabel, theme }): SimpleInterpolation =>
+		$hasLabel ? css`calc(${theme.sizes.font.extrasmall} * 1.5)` : '0px'};
+	max-height: ${({ $maxHeight }): SimpleInterpolation => $maxHeight};
+	overflow-y: auto;
+	font-size: ${({ theme }): string => theme.sizes.font.medium};
+	font-weight: ${({ theme }): number => theme.fonts.weight.regular};
+	font-family: ${({ theme }): string => theme.fonts.default};
+	line-height: 1.5;
+	/** set cursor auto so that the scrollbar keep the default cursor and not the text one */
+	cursor: auto;
+
+	/* easy way to plop the elements on top of each other and have them both sized based on the tallest one's height */
+	display: grid;
+
+	&::after {
+		/* Note the weird space! Needed to prevent jumpy behavior */
+		content: attr(data-replicated-value) ' ';
+		/* This is how textarea text behaves */
+		white-space: pre-wrap;
+		/* Hidden from view, clicks, and screen readers */
+		visibility: hidden;
+	}
+
+	& > textarea,
+	&::after {
+		/* Place on top of each other */
+		grid-area: 1 / 1 / 2 / 2;
+	}
+
+	&::-webkit-scrollbar {
+		width: 0.5rem;
+	}
+
+	&::-webkit-scrollbar-track {
+		background-color: transparent;
+	}
+
+	&::-webkit-scrollbar-thumb {
+		background-color: ${({ theme }): string => theme.palette.gray2.regular};
+		border-radius: 0.25rem;
+	}
+`;
+
+const AdjustHeightTextArea = React.forwardRef<HTMLTextAreaElement, AdjustHeightTextAreaProps>(
+	function AdjustTextAreaHeightFn({ hasLabel, onInput, color, ...props }, ref) {
+		const { maxHeight } = props;
+		const containerRef = useRef<HTMLDivElement>(null);
+		const textAreaRef = useCombinedRefs<HTMLTextAreaElement>(ref);
+
+		useEffect(() => {
+			if (containerRef.current) {
+				// init grow container value to textarea value
+				containerRef.current.dataset.replicatedValue = textAreaRef.current?.value || '';
+			}
+		}, [textAreaRef]);
+
+		const resizeTextArea = useCallback(() => {
+			if (containerRef.current) {
+				containerRef.current.dataset.replicatedValue = textAreaRef.current?.value || '';
+			}
+		}, [textAreaRef]);
+
+		const onInputHandler = useCallback<NonNullable<HTMLTextAreaProps['onInput']>>(
+			(event) => {
+				resizeTextArea();
+				onInput?.(event);
+			},
+			[resizeTextArea, onInput]
+		);
+
+		return (
+			<GrowContainer $hasLabel={hasLabel} $maxHeight={maxHeight} ref={containerRef}>
+				<StyledTextArea
+					{...props}
+					$color={color}
+					onInput={onInputHandler}
+					rows={1}
+					ref={textAreaRef}
+				/>
+			</GrowContainer>
+		);
+	}
+);
+
+const Label = styled(InputLabel)<{ $textAreaHasValue: boolean }>`
+	${InputContainer}:focus-within & {
+		top: 0.0625rem;
+		transform: translateY(0);
+		font-size: ${({ theme }): string => theme.sizes.font.extrasmall};
+	}
+	${({ $textAreaHasValue, theme }): SimpleInterpolation =>
+		$textAreaHasValue &&
+		css`
+			top: 0.0625rem;
+			transform: translateY(0);
+			font-size: ${theme.sizes.font.extrasmall};
+		`};
+`;
+
+const TextArea: TextArea = React.forwardRef<HTMLDivElement, TextAreaProps>(function TextAreaFn(
+	{
+		maxHeight = '10.313rem',
+		hasError,
+		textAreaRef = null,
+		label,
+		description,
+		backgroundColor = 'gray5',
+		textColor = 'text',
+		borderColor = 'gray2',
+		...props
+	},
+	ref
+) {
+	const { defaultValue, value, onInput, disabled, onFocus, onBlur } = props;
+	const innerTextAreaRef = useCombinedRefs(textAreaRef);
+	const [hasFocus, setHasFocus] = useState(false);
+	const [textAreaHasValue, setTextAreaHasValue] = useState(!!defaultValue || !!value);
+
+	const [id] = useState<string>(() => {
+		if (TextArea._newId === undefined) {
+			TextArea._newId = 0;
+		}
+		TextArea._newId += 1;
+		return `textarea-${TextArea._newId}`;
+	});
+
+	const onTextAreaFocus = useCallback<NonNullable<HTMLTextAreaProps['onFocus']>>(
+		(event) => {
+			if (!disabled && innerTextAreaRef.current) {
+				setHasFocus(true);
+			}
+			onFocus?.(event);
+		},
+		[disabled, innerTextAreaRef, onFocus]
+	);
+
+	const onTextAreaBlur = useCallback<NonNullable<HTMLTextAreaProps['onBlur']>>(
+		(event) => {
+			setHasFocus(false);
+			onBlur?.(event);
+		},
+		[onBlur]
+	);
+
+	const onTextAreaInput = useCallback<NonNullable<HTMLTextAreaProps['onInput']>>(
+		(event) => {
+			setTextAreaHasValue(!!event.currentTarget.value);
+			onInput?.(event);
+		},
+		[onInput]
+	);
+
+	const forceFocusOnTextArea = useCallback(() => {
+		if (!disabled && innerTextAreaRef.current) {
+			setHasFocus(true);
+			innerTextAreaRef.current.focus();
+		}
+	}, [disabled, innerTextAreaRef]);
+
+	const dividerColor = useMemo<DividerProps['color']>(
+		() =>
+			`${(hasError && 'error') || (hasFocus && 'primary') || borderColor}${
+				disabled ? '.disabled' : ''
+			}`,
+		[borderColor, disabled, hasError, hasFocus]
+	);
+
+	const descriptionColor = useMemo<TextProps['color']>(
+		() => (hasError && 'error') || (hasFocus && 'primary') || 'secondary',
+		[hasError, hasFocus]
+	);
+
+	return (
+		<Container height="fit" width="fill" crossAlignment="flex-start" ref={ref}>
+			<InputContainer
+				orientation="horizontal"
+				width="fill"
+				height="fit"
+				crossAlignment={label ? 'flex-end' : 'center'}
+				borderRadius="half"
+				background={backgroundColor}
+				onClick={forceFocusOnTextArea}
+				$disabled={disabled}
+				$hasLabel={!!label}
+			>
+				<AdjustHeightTextArea
+					maxHeight={maxHeight}
+					placeholder={label}
+					color={textColor}
+					{...props}
+					id={id}
+					ref={innerTextAreaRef}
+					onInput={onTextAreaInput}
+					onFocus={onTextAreaFocus}
+					onBlur={onTextAreaBlur}
+					hasLabel={!!label}
+				/>
+				{label && (
+					<Label
+						htmlFor={id}
+						$hasFocus={hasFocus}
+						$hasError={hasError}
+						$disabled={disabled}
+						$textAreaHasValue={textAreaHasValue}
+					>
+						{label}
+					</Label>
+				)}
+			</InputContainer>
+			<Divider color={dividerColor} />
+			{description !== undefined && (
+				<InputDescription color={descriptionColor} disabled={disabled}>
+					{description}
+				</InputDescription>
+			)}
+		</Container>
+	);
+});
+
+export { TextArea, TextAreaProps };

--- a/src/components/inputs/commons/InputContainer.tsx
+++ b/src/components/inputs/commons/InputContainer.tsx
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import styled, { css, SimpleInterpolation } from 'styled-components';
+
+import { getColor, pseudoClasses } from '../../../theme/theme-utils';
+import { Container, ContainerProps } from '../../layout/Container';
+
+export const InputContainer = styled(Container)<{
+	background: NonNullable<ContainerProps['background']>;
+	$disabled?: boolean;
+	$hasLabel?: boolean;
+}>`
+	position: relative;
+	${({ $disabled, background, theme }): SimpleInterpolation =>
+		$disabled
+			? css`
+					background: ${getColor(`${background}.disabled`, theme)};
+			  `
+			: css`
+					cursor: text;
+					${pseudoClasses(theme, background)}
+			  `};
+	padding: ${({ $hasLabel }): string => ($hasLabel ? '0.0625rem' : '0.625rem')} 0.75rem;
+	gap: 0.5rem;
+	min-height: calc(
+		${({ theme }): string => theme.sizes.font.medium} * 1.5 +
+			${({ theme }): string => theme.sizes.font.extrasmall} * 1.5 + 0.125rem
+	);
+`;

--- a/src/components/inputs/commons/InputDescription.tsx
+++ b/src/components/inputs/commons/InputDescription.tsx
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import styled from 'styled-components';
+
+import { Text } from '../../basic/Text';
+
+export const InputDescription = styled(Text).attrs({
+	overflow: 'break-word',
+	size: 'extrasmall'
+})`
+	line-height: 1.5;
+	padding-top: 0.25rem;
+	min-height: calc(${({ theme, size }): string => theme.sizes.font[size]} * 1.5);
+`;

--- a/src/components/inputs/commons/InputLabel.tsx
+++ b/src/components/inputs/commons/InputLabel.tsx
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import styled, { SimpleInterpolation } from 'styled-components';
+
+import { getColor } from '../../../theme/theme-utils';
+
+export const InputLabel = styled.label.attrs<
+	{
+		$hasError?: boolean;
+		$hasFocus?: boolean;
+		$disabled?: boolean;
+	},
+	{ $textColor: string }
+>(({ $hasError, $hasFocus }) => ({
+	$textColor: ($hasError && 'error') || ($hasFocus && 'primary') || 'secondary'
+}))<{
+	$hasError?: boolean;
+	$hasFocus?: boolean;
+	$disabled?: boolean;
+}>`
+	position: absolute;
+	top: 50%;
+	left: 0.75rem;
+	font-size: ${({ theme }): string => theme.sizes.font.medium};
+	font-weight: ${({ theme }): number => theme.fonts.weight.regular};
+	font-family: ${({ theme }): string => theme.fonts.default};
+	line-height: 1.5;
+	color: ${({ theme, $textColor, $disabled }): SimpleInterpolation =>
+		getColor(`${$textColor}.${$disabled ? 'disabled' : 'regular'}`, theme)};
+	transform: translateY(-50%);
+	transition: transform 150ms ease-out, font-size 150ms ease-out, top 150ms ease-out,
+		left 150ms ease-out;
+	cursor: inherit;
+	user-select: none;
+	max-width: calc(100% - ${({ theme }): string => `${theme.sizes.padding.large} * 2`});
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+`;

--- a/src/components/layout/Divider.tsx
+++ b/src/components/layout/Divider.tsx
@@ -17,7 +17,7 @@ interface DividerProps extends HTMLAttributes<HTMLDivElement> {
 
 const DividerEl = styled.div<DividerProps>`
 	box-sizing: border-box;
-	border-bottom: 0.0625rem solid ${({ theme, color }): string => getColor(color, theme)};
+	background-color: ${({ theme, color }): string => getColor(color, theme)};
 	height: 0.0625rem;
 	max-height: 0.0625rem;
 	min-height: 0.0625rem;

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ export * from './components/inputs/Select';
 export * from './components/inputs/Switch';
 export * from './components/inputs/DateTimePicker';
 export * from './components/inputs/Slider';
+export * from './components/inputs/TextArea';
 
 /** navigation components */
 export * from './components/navigation/Accordion';

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -71,7 +71,7 @@ module.exports = {
 				},
 				{
 					name: 'Inputs',
-					components: 'src/components/inputs/**/*.[j|t]sx',
+					components: 'src/components/inputs/*.[j|t]sx',
 					exampleMode: 'collapse',
 					usageMode: 'expand'
 				},


### PR DESCRIPTION
Create TextArea component, add tests and documentation.

refactor: extract common internal components for input-like components.

Replace replicas of these common components in Input and ChipInput.

fix(Divider): update Divider to set color for background instead of border

Setting border was creating an empty space above the border when page has a big zoom. By removing the border and setting the color in the background, this empty space is removed.

docs: update styleguide config to exclude subdirectories for inputs folder

refs: CDS-124