### PR TITLE
fix(DateTimePicker): validate typed value of the input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@popperjs/core": "2.11.6",
 				"darkreader": "4.9.58",
 				"polished": "4.2.2",
-				"react-datepicker": "^4.8.0",
+				"react-datepicker": "^4.11.0",
 				"react-docgen-typescript": "^2.2.2"
 			},
 			"devDependencies": {
@@ -19157,16 +19157,16 @@
 			}
 		},
 		"node_modules/react-datepicker": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.8.0.tgz",
-			"integrity": "sha512-u69zXGHMpxAa4LeYR83vucQoUCJQ6m/WBsSxmUMu/M8ahTSVMMyiyQzauHgZA2NUr9y0FUgOAix71hGYUb6tvg==",
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.11.0.tgz",
+			"integrity": "sha512-50n93o7mQwBEhg05tbopjFKgs8qgi8VBCAOMC4VqrKut72eAjESc/wXS/k5hRtnP0oe2FCGw7MJuIwh37wuXOw==",
 			"dependencies": {
 				"@popperjs/core": "^2.9.2",
 				"classnames": "^2.2.6",
 				"date-fns": "^2.24.0",
 				"prop-types": "^15.7.2",
-				"react-onclickoutside": "^6.12.0",
-				"react-popper": "^2.2.5"
+				"react-onclickoutside": "^6.12.2",
+				"react-popper": "^2.3.0"
 			},
 			"peerDependencies": {
 				"react": "^16.9.0 || ^17 || ^18",
@@ -38161,16 +38161,16 @@
 			}
 		},
 		"react-datepicker": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.8.0.tgz",
-			"integrity": "sha512-u69zXGHMpxAa4LeYR83vucQoUCJQ6m/WBsSxmUMu/M8ahTSVMMyiyQzauHgZA2NUr9y0FUgOAix71hGYUb6tvg==",
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.11.0.tgz",
+			"integrity": "sha512-50n93o7mQwBEhg05tbopjFKgs8qgi8VBCAOMC4VqrKut72eAjESc/wXS/k5hRtnP0oe2FCGw7MJuIwh37wuXOw==",
 			"requires": {
 				"@popperjs/core": "^2.9.2",
 				"classnames": "^2.2.6",
 				"date-fns": "^2.24.0",
 				"prop-types": "^15.7.2",
-				"react-onclickoutside": "^6.12.0",
-				"react-popper": "^2.2.5"
+				"react-onclickoutside": "^6.12.2",
+				"react-popper": "^2.3.0"
 			},
 			"dependencies": {
 				"react-onclickoutside": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
 		"@popperjs/core": "2.11.6",
 		"darkreader": "4.9.58",
 		"polished": "4.2.2",
-		"react-datepicker": "^4.8.0",
+		"react-datepicker": "^4.11.0",
 		"react-docgen-typescript": "^2.2.2"
 	}
 }

--- a/src/components/feedback/Banner.test.tsx
+++ b/src/components/feedback/Banner.test.tsx
@@ -13,6 +13,7 @@ import 'jest-styled-components';
 import { find as findStyled } from 'styled-components/test-utils';
 
 import { render } from '../../test-utils';
+import { ICONS } from '../../testUtils/constants';
 import { Theme } from '../../theme/theme';
 import { ModalManager } from '../utilities/ModalManager';
 import { Banner, BannerProps, InfoContainer } from './Banner';
@@ -134,7 +135,7 @@ describe('Banner', () => {
 				Theme.palette[mainColor].regular
 			);
 
-			expect(getByRoleWithIcon('button', { icon: 'Close' })).toHaveStyleRule(
+			expect(getByRoleWithIcon('button', { icon: ICONS.close })).toHaveStyleRule(
 				'color',
 				Theme.palette[textColor].regular
 			);
@@ -186,7 +187,7 @@ describe('Banner', () => {
 
 	test('Close action is hidden by default', () => {
 		const { queryByRoleWithIcon } = render(<Banner description={'Banner'} />);
-		expect(queryByRoleWithIcon('button', { icon: 'Close' })).not.toBeInTheDocument();
+		expect(queryByRoleWithIcon('button', { icon: ICONS.close })).not.toBeInTheDocument();
 	});
 
 	test('Close action is shown if showClose is true', () => {
@@ -194,7 +195,7 @@ describe('Banner', () => {
 		const { getByRoleWithIcon } = render(
 			<Banner description={'Banner'} showClose onClose={closeFn} />
 		);
-		const closeAction = getByRoleWithIcon('button', { icon: 'Close' });
+		const closeAction = getByRoleWithIcon('button', { icon: ICONS.close });
 		expect(closeAction).toBeVisible();
 		userEvent.click(closeAction);
 		expect(closeFn).toHaveBeenCalled();
@@ -308,7 +309,7 @@ describe('Banner', () => {
 		expect(infoContainer).not.toBeNull();
 		makeTextCropped(resizeObserver, infoContainer as HTMLElement);
 		const modal = await openMoreInfoModal();
-		const closeAction = getByRoleWithIcon('button', { icon: 'Close' });
+		const closeAction = getByRoleWithIcon('button', { icon: ICONS.close });
 		expect(closeAction).toBeVisible();
 		expect(closeAction).toBeVisible();
 		userEvent.click(closeAction);

--- a/src/components/inputs/ChipInput.test.tsx
+++ b/src/components/inputs/ChipInput.test.tsx
@@ -355,7 +355,7 @@ describe('ChipInput', () => {
 	});
 
 	test('click on an option without a custom click callback creates a chip, close dropdown and clear the input', () => {
-		const options: NonNullable<ChipInputProps['options']> = [
+		const options: NonNullable<ChipInputProps<never>['options']> = [
 			{ id: 'opt1', label: 'option 1' },
 			{ id: 'opt2', label: 'option 2' }
 		];
@@ -377,7 +377,7 @@ describe('ChipInput', () => {
 	});
 
 	test('click on an option with a custom click callback creates a chip, close dropdown and clear the input', () => {
-		const options: NonNullable<ChipInputProps['options']> = [
+		const options: NonNullable<ChipInputProps<never>['options']> = [
 			{ id: 'opt1', label: 'option 1', onClick: jest.fn() },
 			{ id: 'opt2', label: 'option 2', onClick: jest.fn() }
 		];

--- a/src/components/inputs/ChipInput.tsx
+++ b/src/components/inputs/ChipInput.tsx
@@ -231,15 +231,15 @@ const CustomIcon = styled(({ onClick, iconColor, ...rest }) =>
 		`};
 `;
 
-function reducer(
-	state: ChipItem[],
+function reducer<TValue>(
+	state: ChipItem<TValue>[],
 	action:
-		| { type: 'push' | 'replace'; item: ChipItem }
+		| { type: 'push' | 'replace'; item: ChipItem<TValue> }
 		| { type: 'pop'; index: number }
 		| { type: 'popLast' }
-		| { type: 'reset'; value: ChipItem[] | undefined }
-		| { type: 'pushMultiples'; items: ChipItem[] }
-): ChipItem[] {
+		| { type: 'reset'; value: ChipItem<TValue>[] | undefined }
+		| { type: 'pushMultiples'; items: ChipItem<TValue>[] }
+): ChipItem<TValue>[] {
 	switch (action.type) {
 		case 'push':
 			return [...state, action.item];
@@ -271,11 +271,12 @@ function DefaultOnAdd(valueToAdd: unknown | string): { label: string } {
 	return { label: 'unknown value' };
 }
 
-type ChipItem = { label?: string } & ChipProps & {
-		value?: unknown;
+type ChipItem<TValue = unknown> = { label?: string } & ChipProps & {
+		value?: TValue;
 	};
 
-interface ChipInputProps extends Omit<ContainerProps, 'defaultValue' | 'onChange'> {
+interface ChipInputProps<TValue = unknown>
+	extends Omit<ContainerProps, 'defaultValue' | 'onChange'> {
 	/** ref to the input element */
 	inputRef?: React.MutableRefObject<HTMLInputElement | null>;
 	/** HTML input name */
@@ -283,11 +284,11 @@ interface ChipInputProps extends Omit<ContainerProps, 'defaultValue' | 'onChange
 	/** Input Placeholder */
 	placeholder?: string;
 	/** ChipInput value */
-	value?: ChipItem[];
+	value?: ChipItem<TValue>[];
 	/** ChipInput default value */
-	defaultValue?: ChipItem[];
+	defaultValue?: ChipItem<TValue>[];
 	/** Callback to call when ChipInput's value changes */
-	onChange?: (items: ChipItem[]) => void;
+	onChange?: (items: ChipItem<TValue>[]) => void;
 	/**
 	 * Dropdown items.
 	 * If disableOptions is true but options are provided, dropdown is still shown.
@@ -299,11 +300,13 @@ interface ChipInputProps extends Omit<ContainerProps, 'defaultValue' | 'onChange
 	 * - returns the keyup event object with an additional textContent value
 	 * - the event is debounced using the debounce function from lodash
 	 */
-	onInputType?: (event: React.KeyboardEvent & { textContent: string | null }) => void;
+	onInputType?: (
+		event: React.KeyboardEvent<HTMLInputElement> & { textContent: string | null }
+	) => void;
 	/** Debounce value in ms to which debounce the 'onInputType' callback */
 	onInputTypeDebounce?: number;
 	/** Callback called when a value is going to be added in the Chip Input, should return the configuration for the Chip */
-	onAdd?: (value: string | unknown) => ChipItem;
+	onAdd?: (value: string | unknown) => ChipItem<TValue>;
 	/** Set the current input text as a Chip when it loses focus */
 	confirmChipOnBlur?: boolean;
 	/**
@@ -363,7 +366,7 @@ interface ChipInputProps extends Omit<ContainerProps, 'defaultValue' | 'onChange
 	/** Description for the input */
 	description?: string | undefined;
 	/** Custom Chip component */
-	ChipComponent?: React.ComponentType<ChipItem>;
+	ChipComponent?: React.ComponentType<ChipItem<TValue>>;
 	/** allow to create chips from pasted values */
 	createChipOnPaste?: boolean;
 	/** Chip generation triggers on paste */
@@ -374,434 +377,444 @@ interface ChipInputProps extends Omit<ContainerProps, 'defaultValue' | 'onChange
 	maxHeight?: string;
 }
 
-type ChipInput = React.ForwardRefExoticComponent<
-	ChipInputProps & React.RefAttributes<HTMLDivElement>
+type ChipInputType<TValue> = React.ForwardRefExoticComponent<
+	ChipInputProps<TValue> & React.RefAttributes<HTMLDivElement>
 > & {
 	_newId?: number;
 };
 
-const ChipInput: ChipInput = React.forwardRef<HTMLDivElement, ChipInputProps>(function ChipInputFn(
-	{
-		inputRef = null,
-		inputName,
-		placeholder,
-		value,
-		defaultValue,
-		onChange,
-		options = [],
-		onInputType,
-		onInputTypeDebounce = 300,
-		onAdd = DefaultOnAdd,
-		background = INPUT_BACKGROUND_COLOR,
-		confirmChipOnBlur = true,
-		confirmChipOnSpace = true,
-		separators = ['Enter', 'NumpadEnter', 'Comma', 'Space'],
-		icon,
-		iconAction,
-		iconDisabled = false,
-		iconColor,
-		disabled = false,
-		requireUniqueChips = false,
-		createChipOnPaste = false,
-		pasteSeparators = [','],
-		maxChips = 20,
-		hasError = false,
-		hideBorder = false,
-		errorLabel,
-		errorBackgroundColor,
-		disableOptions = true,
-		singleSelection = false,
-		bottomBorderColor = INPUT_DIVIDER_COLOR,
-		dropdownMaxHeight,
-		description,
-		ChipComponent,
-		wrap = 'wrap',
-		maxHeight = '8.125rem',
-		...rest
-	},
-	ref
-) {
-	const [items, dispatch] = useReducer(reducer, defaultValue || value || []);
-	const [isActive, setIsActive] = useState(false);
-	const inputElRef = useCombinedRefs<HTMLInputElement>(inputRef);
-	const scrollContainerRef = useRef<HTMLDivElement | null>(null);
-	const scrollAfterSaveRef = useRef(false);
-
-	const [id] = useState(() => {
-		if (!ChipInput._newId) {
-			ChipInput._newId = 0;
-		}
-		// eslint-disable-next-line no-plusplus
-		return `chipInput-${ChipInput._newId++}`;
-	});
-
-	const [forceShowDropdown, setForceShowDropdown] = useState(false);
-	const [dropdownItems, setDropdownItems] = useState<DropdownItem[]>(options);
-
-	const uncontrolledMode = useMemo(() => value === undefined, [value]);
-
-	// TODO: remove together with confirmChipOnSpace
-	const separatorKeys = useMemo(() => {
-		const keys = [...separators];
-		const index = keys.indexOf('Space');
-		if (confirmChipOnSpace && index < 0) {
-			keys.push('Space');
-		} else if (!confirmChipOnSpace && index >= 0) {
-			keys.splice(index, 1);
-		}
-		return keys;
-	}, [confirmChipOnSpace, separators]);
-
-	const setFocus = useCallback(() => {
-		inputElRef.current && inputElRef.current.focus();
-	}, [inputElRef]);
-
-	const saveValue = useCallback(
-		(valueToSave: string | unknown) => {
-			const trimmedValue = typeof valueToSave === 'string' ? trim(valueToSave) : valueToSave;
-
-			const duplicate =
-				requireUniqueChips &&
-				find(items, {
-					label: trimmedValue
-				});
-
-			if (trimmedValue && !duplicate) {
-				const item = onAdd(trimmedValue);
-				uncontrolledMode && dispatch({ type: 'push', item });
-				onChange && onChange([...items, item]);
-				scrollAfterSaveRef.current = true;
-			}
-			if (inputElRef.current) {
-				inputElRef.current.value = '';
-				inputElRef.current.dispatchEvent(new Event('change'));
-			}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const ChipInput: ChipInputType<any> = React.forwardRef<HTMLDivElement, ChipInputProps<any>>(
+	function ChipInputFn(
+		{
+			inputRef = null,
+			inputName,
+			placeholder,
+			value,
+			defaultValue,
+			onChange,
+			options = [],
+			onInputType,
+			onInputTypeDebounce = 300,
+			onAdd = DefaultOnAdd,
+			background = INPUT_BACKGROUND_COLOR,
+			confirmChipOnBlur = true,
+			confirmChipOnSpace = true,
+			separators = ['Enter', 'NumpadEnter', 'Comma', 'Space'],
+			icon,
+			iconAction,
+			iconDisabled = false,
+			iconColor,
+			disabled = false,
+			requireUniqueChips = false,
+			createChipOnPaste = false,
+			pasteSeparators = [','],
+			maxChips = 20,
+			hasError = false,
+			hideBorder = false,
+			errorLabel,
+			errorBackgroundColor,
+			disableOptions = true,
+			singleSelection = false,
+			bottomBorderColor = INPUT_DIVIDER_COLOR,
+			dropdownMaxHeight,
+			description,
+			ChipComponent,
+			wrap = 'wrap',
+			maxHeight = '8.125rem',
+			...rest
 		},
-		[requireUniqueChips, items, inputElRef, onAdd, uncontrolledMode, onChange]
-	);
+		ref
+	) {
+		const [items, dispatch] = useReducer(reducer, defaultValue || value || []);
+		const [isActive, setIsActive] = useState(false);
+		const inputElRef = useCombinedRefs<HTMLInputElement>(inputRef);
+		const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+		const scrollAfterSaveRef = useRef(false);
 
-	const savePastedValue = useCallback(
-		(valueToSave: string[]) => {
-			const pastedItems = map(valueToSave, (vts) => onAdd(vts));
-			uncontrolledMode && dispatch({ type: 'pushMultiples', items: pastedItems });
-			onChange && onChange([...items, ...pastedItems]);
-		},
-		[uncontrolledMode, onChange, items, onAdd]
-	);
-
-	const replaceValue = useCallback(
-		(valueToSave: string | unknown) => {
-			const item = onAdd(valueToSave);
-			uncontrolledMode && dispatch({ type: 'replace', item });
-			onChange && onChange([...items, item]);
-			if (inputElRef.current) {
-				inputElRef.current.value = '';
-				inputElRef.current.dispatchEvent(new Event('change'));
+		const [id] = useState(() => {
+			if (!ChipInput._newId) {
+				ChipInput._newId = 0;
 			}
-		},
-		[onAdd, uncontrolledMode, onChange, items, inputElRef]
-	);
-
-	const saveCurrentValue = useCallback(() => {
-		const inputValue = inputElRef.current?.value || '';
-		inputValue.length && saveValue(inputValue);
-	}, [inputElRef, saveValue]);
-
-	const saveCurrentEvent = useMemo(
-		() => getKeyboardPreset('chipInputKeys', saveCurrentValue, undefined, separatorKeys),
-		[saveCurrentValue, separatorKeys]
-	);
-
-	useKeyboard(inputElRef, saveCurrentEvent);
-
-	const onBackspace = useCallback(
-		(e: KeyboardEvent) => {
-			const inputElement = e.currentTarget instanceof HTMLInputElement && e.currentTarget;
-			if (
-				inputElement &&
-				inputElement.selectionStart === 0 &&
-				inputElement.selectionStart === inputElement.selectionEnd
-			) {
-				e.preventDefault();
-				uncontrolledMode && dispatch({ type: 'popLast' });
-				onChange && onChange(slice(items, 0, items.length - 1));
-				return false;
-			}
-			return true;
-		},
-		[uncontrolledMode, onChange, items]
-	);
-
-	const backspaceEvent = useMemo<KeyboardPreset>(
-		() => [
-			{
-				type: 'keydown',
-				callback: onBackspace,
-				keys: ['Backspace'],
-				haveToPreventDefault: false
-			}
-		],
-		[onBackspace]
-	);
-
-	useKeyboard(inputElRef, backspaceEvent);
-
-	const onChipClose = useCallback(
-		(index: number) => {
-			uncontrolledMode && dispatch({ type: 'pop', index });
-			onChange && onChange(filter(items, (item, i) => index !== i));
-			if (inputElRef.current) {
-				inputElRef.current.focus();
-			}
-		},
-		[inputElRef, items, onChange, uncontrolledMode]
-	);
-
-	const onInputBlur = useCallback(() => {
-		setIsActive(false);
-		confirmChipOnBlur && options.length === 0 && saveCurrentValue();
-	}, [confirmChipOnBlur, options, saveCurrentValue]);
-
-	const onInputKeyUp = useMemo(
-		() =>
-			debounce((ev: React.KeyboardEvent) => {
-				if (onInputType) {
-					onInputType({
-						...ev,
-						textContent: inputElRef.current && inputElRef.current.value
-					});
-				}
-			}, onInputTypeDebounce),
-		[inputElRef, onInputType, onInputTypeDebounce]
-	);
-
-	const onOptionClick = useCallback(
-		(valueToAdd: string | unknown) => {
-			singleSelection ? replaceValue(valueToAdd) : saveValue(valueToAdd);
-			setFocus();
-		},
-		[saveValue, setFocus, singleSelection, replaceValue]
-	);
-
-	const onClose = useCallback(() => {
-		setForceShowDropdown(false);
-	}, []);
-
-	useEffect(() => {
-		!uncontrolledMode && dispatch({ type: 'reset', value });
-	}, [uncontrolledMode, value]);
-
-	useEffect(() => {
-		setDropdownItems((prevState) => {
-			if (options.length === 0 && prevState.length === 0) {
-				return prevState;
-			}
-			return map(options, (o) => ({
-				...o,
-				onClick: (event): void => {
-					o.onClick && o.onClick(event);
-					onOptionClick(o.value ? o.value : o.label);
-				}
-			}));
+			// eslint-disable-next-line no-plusplus
+			return `chipInput-${ChipInput._newId++}`;
 		});
-	}, [onOptionClick, options]);
 
-	// allow horizontal scroll without a scroll bar
-	const flipScroll = useCallback<(e: WheelEvent) => void>((ev) => {
-		const scrollableElement = ev.currentTarget;
-		if (
-			scrollableElement &&
-			scrollableElement instanceof HTMLElement &&
-			// avoid to catch scroll if entire content is visible
-			scrollableElement.scrollWidth > scrollableElement.clientWidth
-		) {
-			ev.preventDefault();
-			scrollableElement.scrollLeft += ev.deltaY;
-		}
-	}, []);
+		const [forceShowDropdown, setForceShowDropdown] = useState(false);
+		const [dropdownItems, setDropdownItems] = useState<DropdownItem[]>(options);
 
-	useEffect(() => {
-		const wrapperElement = scrollContainerRef.current;
-		wrapperElement && wrapperElement.addEventListener('wheel', flipScroll);
-		return () => {
-			wrapperElement && wrapperElement.removeEventListener('wheel', flipScroll);
-		};
-	}, [flipScroll, scrollContainerRef]);
+		const uncontrolledMode = useMemo(() => value === undefined, [value]);
 
-	useEffect(() => {
-		/*
-		 * Scroll to end of horizontal scrollable container when items change and when
-		 * scrollAfterSave is true, so that the last chip is fully visible and also the input.
-		 * This is done with an effect to be sure both keyboard and blur events trigger this
-		 * calc with the final dimensions of the container
-		 */
-		if (scrollAfterSaveRef.current && scrollContainerRef.current) {
-			// scroll to the end so the newly added chip is fully shown
-			scrollContainerRef.current.scrollLeft = scrollContainerRef.current.scrollWidth;
-			scrollAfterSaveRef.current = false;
-		}
-	}, [items]);
-
-	const inputDisabled = useMemo(
-		() => !!maxChips && items.length >= maxChips,
-		[items.length, maxChips]
-	);
-
-	const previousInputDisabled = usePrevious<boolean>(inputDisabled);
-
-	useEffect(() => {
-		if (inputDisabled && !previousInputDisabled) {
-			setIsActive(false);
-		}
-	}, [previousInputDisabled, inputDisabled]);
-
-	// dropdown disabled does not depend on chipInput disabled, so that options can be still used
-	// even if input is disabled (chip can be added through dropdown but not typing)
-	const dropdownDisabled = useMemo(
-		() => disableOptions || inputDisabled,
-		[disableOptions, inputDisabled]
-	);
-
-	useEffect(() => {
-		// if dropdown is set to not open on click (dropdownDisabled),
-		// force open it on options change to simulate suggestion mode
-		setForceShowDropdown(dropdownDisabled && !isEmpty(options));
-	}, [dropdownDisabled, options]);
-
-	const hasFocus = useMemo(() => isActive && !inputDisabled, [isActive, inputDisabled]);
-
-	const onInputFocus = useCallback(() => setIsActive(true), []);
-
-	const onPaste = useCallback<React.ClipboardEventHandler>(
-		(e) => {
-			if (createChipOnPaste) {
-				e.preventDefault();
-				const pastedText = e.clipboardData.getData('Text');
-				const separatorsRegex = new RegExp(pasteSeparators.join('|'), 'gi');
-				const reducedChips = reduce<string, string[]>(
-					pastedText.split(separatorsRegex),
-					(acc, v) => {
-						if (trim(v) !== '') acc.push(trim(v));
-						return acc;
-					},
-					[]
-				);
-				savePastedValue(requireUniqueChips ? uniq(reducedChips) : reducedChips);
+		// TODO: remove together with confirmChipOnSpace
+		const separatorKeys = useMemo(() => {
+			const keys = [...separators];
+			const index = keys.indexOf('Space');
+			if (confirmChipOnSpace && index < 0) {
+				keys.push('Space');
+			} else if (!confirmChipOnSpace && index >= 0) {
+				keys.splice(index, 1);
 			}
-		},
-		[createChipOnPaste, pasteSeparators, requireUniqueChips, savePastedValue]
-	);
+			return keys;
+		}, [confirmChipOnSpace, separators]);
 
-	const ChipComp = useMemo(() => ChipComponent || Chip, [ChipComponent]);
+		const setFocus = useCallback(() => {
+			inputElRef.current && inputElRef.current.focus();
+		}, [inputElRef]);
 
-	const dividerColor = useMemo<DividerProps['color']>(
-		() =>
-			`${
-				(hideBorder && 'transparent') ||
-				(hasError && 'error') ||
-				(hasFocus && 'primary') ||
-				bottomBorderColor
-			}${disabled ? '.disabled' : ''}`,
-		[bottomBorderColor, disabled, hasError, hasFocus, hideBorder]
-	);
+		const saveValue = useCallback(
+			(valueToSave: unknown) => {
+				const trimmedValue = typeof valueToSave === 'string' ? trim(valueToSave) : valueToSave;
 
-	return (
-		<Container height="fit" width="fill" crossAlignment="flex-start">
-			<Dropdown
-				items={dropdownItems}
-				display="block"
-				width="100%"
-				disableAutoFocus
-				disableRestoreFocus
-				forceOpen={forceShowDropdown}
-				onClose={onClose}
-				disabled={dropdownDisabled}
-				maxHeight={dropdownMaxHeight}
-			>
-				<ContainerEl
-					ref={ref}
-					orientation="horizontal"
-					width="fill"
-					height="fit"
-					mainAlignment="flex-start"
-					crossAlignment={placeholder ? 'flex-end' : 'center'}
-					borderRadius="half"
-					background={background}
-					$hasLabel={!!placeholder}
-					$inputDisabled={disabled || inputDisabled}
-					$dropdownDisabled={dropdownDisabled}
-					onClick={setFocus}
-					{...rest}
+				const duplicate =
+					requireUniqueChips &&
+					find(items, {
+						label: trimmedValue
+					});
+
+				if (trimmedValue && !duplicate) {
+					const item = onAdd(trimmedValue);
+					uncontrolledMode && dispatch({ type: 'push', item });
+					onChange && onChange([...items, item]);
+					scrollAfterSaveRef.current = true;
+				}
+				if (inputElRef.current) {
+					inputElRef.current.value = '';
+					inputElRef.current.dispatchEvent(new Event('change'));
+				}
+			},
+			[requireUniqueChips, items, inputElRef, onAdd, uncontrolledMode, onChange]
+		);
+
+		const savePastedValue = useCallback(
+			(valueToSave: string[]) => {
+				const pastedItems = map(valueToSave, (vts) => onAdd(vts));
+				uncontrolledMode && dispatch({ type: 'pushMultiples', items: pastedItems });
+				onChange && onChange([...items, ...pastedItems]);
+			},
+			[uncontrolledMode, onChange, items, onAdd]
+		);
+
+		const replaceValue = useCallback(
+			(valueToSave: string | unknown) => {
+				const item = onAdd(valueToSave);
+				uncontrolledMode && dispatch({ type: 'replace', item });
+				onChange && onChange([...items, item]);
+				if (inputElRef.current) {
+					inputElRef.current.value = '';
+					inputElRef.current.dispatchEvent(new Event('change'));
+				}
+			},
+			[onAdd, uncontrolledMode, onChange, items, inputElRef]
+		);
+
+		const saveCurrentValue = useCallback(() => {
+			const inputValue = inputElRef.current?.value || '';
+			inputValue.length && saveValue(inputValue);
+		}, [inputElRef, saveValue]);
+
+		const saveCurrentEvent = useMemo(
+			() => getKeyboardPreset('chipInputKeys', saveCurrentValue, undefined, separatorKeys),
+			[saveCurrentValue, separatorKeys]
+		);
+
+		useKeyboard(inputElRef, saveCurrentEvent);
+
+		const onBackspace = useCallback(
+			(e: KeyboardEvent) => {
+				const inputElement = e.currentTarget instanceof HTMLInputElement && e.currentTarget;
+				if (
+					inputElement &&
+					inputElement.selectionStart === 0 &&
+					inputElement.selectionStart === inputElement.selectionEnd
+				) {
+					e.preventDefault();
+					uncontrolledMode && dispatch({ type: 'popLast' });
+					onChange && onChange(slice(items, 0, items.length - 1));
+					return false;
+				}
+				return true;
+			},
+			[uncontrolledMode, onChange, items]
+		);
+
+		const backspaceEvent = useMemo<KeyboardPreset>(
+			() => [
+				{
+					type: 'keydown',
+					callback: onBackspace,
+					keys: ['Backspace'],
+					haveToPreventDefault: false
+				}
+			],
+			[onBackspace]
+		);
+
+		useKeyboard(inputElRef, backspaceEvent);
+
+		const onChipClose = useCallback(
+			(index: number) => {
+				uncontrolledMode && dispatch({ type: 'pop', index });
+				onChange && onChange(filter(items, (item, i) => index !== i));
+				if (inputElRef.current) {
+					inputElRef.current.focus();
+				}
+			},
+			[inputElRef, items, onChange, uncontrolledMode]
+		);
+
+		const onInputBlur = useCallback(() => {
+			setIsActive(false);
+			confirmChipOnBlur && options.length === 0 && saveCurrentValue();
+		}, [confirmChipOnBlur, options, saveCurrentValue]);
+
+		const onInputKeyUp = useMemo(
+			() =>
+				debounce((ev: React.KeyboardEvent<HTMLInputElement>) => {
+					if (onInputType) {
+						onInputType({
+							...ev,
+							textContent: inputElRef.current && inputElRef.current.value
+						});
+					}
+				}, onInputTypeDebounce),
+			[inputElRef, onInputType, onInputTypeDebounce]
+		);
+
+		useEffect(
+			() => () => {
+				onInputKeyUp.cancel();
+			},
+			[onInputKeyUp]
+		);
+
+		const onOptionClick = useCallback(
+			(valueToAdd: string | unknown) => {
+				singleSelection ? replaceValue(valueToAdd) : saveValue(valueToAdd);
+				setFocus();
+			},
+			[saveValue, setFocus, singleSelection, replaceValue]
+		);
+
+		const onClose = useCallback(() => {
+			setForceShowDropdown(false);
+		}, []);
+
+		useEffect(() => {
+			!uncontrolledMode && dispatch({ type: 'reset', value });
+		}, [uncontrolledMode, value]);
+
+		useEffect(() => {
+			setDropdownItems((prevState) => {
+				if (options.length === 0 && prevState.length === 0) {
+					return prevState;
+				}
+				return map(options, (o) => ({
+					...o,
+					onClick: (event): void => {
+						o.onClick && o.onClick(event);
+						onOptionClick(o.value ? o.value : o.label);
+					}
+				}));
+			});
+		}, [onOptionClick, options]);
+
+		// allow horizontal scroll without a scroll bar
+		const flipScroll = useCallback<(e: WheelEvent) => void>((ev) => {
+			const scrollableElement = ev.currentTarget;
+			if (
+				scrollableElement &&
+				scrollableElement instanceof HTMLElement &&
+				// avoid to catch scroll if entire content is visible
+				scrollableElement.scrollWidth > scrollableElement.clientWidth
+			) {
+				ev.preventDefault();
+				scrollableElement.scrollLeft += ev.deltaY;
+			}
+		}, []);
+
+		useEffect(() => {
+			const wrapperElement = scrollContainerRef.current;
+			wrapperElement && wrapperElement.addEventListener('wheel', flipScroll);
+			return () => {
+				wrapperElement && wrapperElement.removeEventListener('wheel', flipScroll);
+			};
+		}, [flipScroll, scrollContainerRef]);
+
+		useEffect(() => {
+			/*
+			 * Scroll to end of horizontal scrollable container when items change and when
+			 * scrollAfterSave is true, so that the last chip is fully visible and also the input.
+			 * This is done with an effect to be sure both keyboard and blur events trigger this
+			 * calc with the final dimensions of the container
+			 */
+			if (scrollAfterSaveRef.current && scrollContainerRef.current) {
+				// scroll to the end so the newly added chip is fully shown
+				scrollContainerRef.current.scrollLeft = scrollContainerRef.current.scrollWidth;
+				scrollAfterSaveRef.current = false;
+			}
+		}, [items]);
+
+		const inputDisabled = useMemo(
+			() => !!maxChips && items.length >= maxChips,
+			[items.length, maxChips]
+		);
+
+		const previousInputDisabled = usePrevious<boolean>(inputDisabled);
+
+		useEffect(() => {
+			if (inputDisabled && !previousInputDisabled) {
+				setIsActive(false);
+			}
+		}, [previousInputDisabled, inputDisabled]);
+
+		// dropdown disabled does not depend on chipInput disabled, so that options can be still used
+		// even if input is disabled (chip can be added through dropdown but not typing)
+		const dropdownDisabled = useMemo(
+			() => disableOptions || inputDisabled,
+			[disableOptions, inputDisabled]
+		);
+
+		useEffect(() => {
+			// if dropdown is set to not open on click (dropdownDisabled),
+			// force open it on options change to simulate suggestion mode
+			setForceShowDropdown(dropdownDisabled && !isEmpty(options));
+		}, [dropdownDisabled, options]);
+
+		const hasFocus = useMemo(() => isActive && !inputDisabled, [isActive, inputDisabled]);
+
+		const onInputFocus = useCallback(() => setIsActive(true), []);
+
+		const onPaste = useCallback<React.ClipboardEventHandler>(
+			(e) => {
+				if (createChipOnPaste) {
+					e.preventDefault();
+					const pastedText = e.clipboardData.getData('Text');
+					const separatorsRegex = new RegExp(pasteSeparators.join('|'), 'gi');
+					const reducedChips = reduce<string, string[]>(
+						pastedText.split(separatorsRegex),
+						(acc, v) => {
+							if (trim(v) !== '') acc.push(trim(v));
+							return acc;
+						},
+						[]
+					);
+					savePastedValue(requireUniqueChips ? uniq(reducedChips) : reducedChips);
+				}
+			},
+			[createChipOnPaste, pasteSeparators, requireUniqueChips, savePastedValue]
+		);
+
+		const ChipComp = useMemo(() => ChipComponent || Chip, [ChipComponent]);
+
+		const dividerColor = useMemo<DividerProps['color']>(
+			() =>
+				`${
+					(hideBorder && 'transparent') ||
+					(hasError && 'error') ||
+					(hasFocus && 'primary') ||
+					bottomBorderColor
+				}${disabled ? '.disabled' : ''}`,
+			[bottomBorderColor, disabled, hasError, hasFocus, hideBorder]
+		);
+
+		return (
+			<Container height="fit" width="fill" crossAlignment="flex-start">
+				<Dropdown
+					items={dropdownItems}
+					display="block"
+					width="100%"
+					disableAutoFocus
+					disableRestoreFocus
+					forceOpen={forceShowDropdown}
+					onClose={onClose}
+					disabled={dropdownDisabled}
+					maxHeight={dropdownMaxHeight}
 				>
-					<ScrollContainer
-						ref={scrollContainerRef}
-						wrap={wrap}
-						maxHeight={maxHeight}
-						hasLabel={!!placeholder}
+					<ContainerEl
+						ref={ref}
+						orientation="horizontal"
+						width="fill"
+						height="fit"
+						mainAlignment="flex-start"
+						crossAlignment={placeholder ? 'flex-end' : 'center'}
+						borderRadius="half"
+						background={background}
+						$hasLabel={!!placeholder}
+						$inputDisabled={disabled || inputDisabled}
+						$dropdownDisabled={dropdownDisabled}
+						onClick={setFocus}
+						{...rest}
 					>
-						{items.length > 0 &&
-							map(items, (item, index) => (
-								<ChipComp
-									key={`${index}-${item.value}`}
-									maxWidth={(wrap === 'wrap' && '100%') || undefined}
-									{...item}
-									closable
-									onClose={(): void => onChipClose(index)}
-								/>
-							))}
-						<AdjustWidthInput
-							color="text"
-							autoComplete="off"
-							ref={inputElRef}
-							onFocus={onInputFocus}
-							onBlur={onInputBlur}
-							onKeyUp={onInputType && onInputKeyUp}
-							id={id}
-							name={inputName || placeholder}
-							disabled={disabled || inputDisabled}
-							placeholder={placeholder}
-							separators={separatorKeys}
-							confirmChipOnBlur={confirmChipOnBlur}
-							onPaste={onPaste}
-						/>
-						{placeholder && (
-							<Label
-								htmlFor={id}
-								$hasFocus={hasFocus}
-								$hasError={hasError}
-								$disabled={disabled && dropdownDisabled && (!iconAction || iconDisabled)}
-								$hasItems={items.length > 0 || !!inputElRef.current?.value}
-							>
-								{placeholder}
-							</Label>
-						)}
-					</ScrollContainer>
-					{icon && (
-						<CustomIconContainer>
-							<CustomIcon
-								icon={icon}
-								onClick={iconAction}
-								disabled={iconDisabled}
-								iconColor={iconColor}
-								size="large"
+						<ScrollContainer
+							ref={scrollContainerRef}
+							wrap={wrap}
+							maxHeight={maxHeight}
+							hasLabel={!!placeholder}
+						>
+							{items.length > 0 &&
+								map(items, (item, index) => (
+									<ChipComp
+										key={`${index}-${item.value}`}
+										maxWidth={(wrap === 'wrap' && '100%') || undefined}
+										{...item}
+										closable
+										onClose={(): void => onChipClose(index)}
+									/>
+								))}
+							<AdjustWidthInput
+								color="text"
+								autoComplete="off"
+								ref={inputElRef}
+								onFocus={onInputFocus}
+								onBlur={onInputBlur}
+								onKeyUp={onInputType && onInputKeyUp}
+								id={id}
+								name={inputName || placeholder}
+								disabled={disabled || inputDisabled}
+								placeholder={placeholder}
+								separators={separatorKeys}
+								confirmChipOnBlur={confirmChipOnBlur}
+								onPaste={onPaste}
 							/>
-						</CustomIconContainer>
-					)}
-				</ContainerEl>
-			</Dropdown>
-			<Divider color={dividerColor} />
-			{((hasError && errorLabel !== undefined) || description !== undefined) && (
-				<CustomInputDescription
-					color={(hasError && 'error') || (hasFocus && 'primary') || 'secondary'}
-					disabled={disabled && dropdownDisabled && (!iconAction || iconDisabled)}
-					$backgroundColor={errorBackgroundColor}
-				>
-					{(hasError && errorLabel) || description}
-				</CustomInputDescription>
-			)}
-		</Container>
-	);
-});
+							{placeholder && (
+								<Label
+									htmlFor={id}
+									$hasFocus={hasFocus}
+									$hasError={hasError}
+									$disabled={disabled && dropdownDisabled && (!iconAction || iconDisabled)}
+									$hasItems={items.length > 0 || !!inputElRef.current?.value}
+								>
+									{placeholder}
+								</Label>
+							)}
+						</ScrollContainer>
+						{icon && (
+							<CustomIconContainer>
+								<CustomIcon
+									icon={icon}
+									onClick={iconAction}
+									disabled={iconDisabled}
+									iconColor={iconColor}
+									size="large"
+								/>
+							</CustomIconContainer>
+						)}
+					</ContainerEl>
+				</Dropdown>
+				<Divider color={dividerColor} />
+				{((hasError && errorLabel !== undefined) || description !== undefined) && (
+					<CustomInputDescription
+						color={(hasError && 'error') || (hasFocus && 'primary') || 'secondary'}
+						disabled={disabled && dropdownDisabled && (!iconAction || iconDisabled)}
+						$backgroundColor={errorBackgroundColor}
+					>
+						{(hasError && errorLabel) || description}
+					</CustomInputDescription>
+				)}
+			</Container>
+		);
+	}
+);
 
 ChipInput._newId = 0;
 

--- a/src/components/inputs/DateTimePicker.md
+++ b/src/components/inputs/DateTimePicker.md
@@ -99,16 +99,20 @@ const ExampleCustomInput = forwardRef(({ value, onClick }, ref) => (
 
 ```jsx
 import { useState } from 'react';
-import { Padding } from '@zextras/carbonio-design-system';
-<>
+import { Container } from '@zextras/carbonio-design-system';
+<Container gap={"1rem"}>
 	<DateTimePicker
-		label="Date Time Picker"
+		label="Date Time Picker With Chips"
+		enableChips
+	/>
+	<DateTimePicker
+		label="With chips and custom format"
 		enableChips
 		includeTime={false}
-		dateFormat="dd/MM/yyyy"
+        dateFormat="dd/MM/yyyy"
 		defaultValue={new Date()}
 	/>
-</>;
+</Container>;
 ```
 
 ### With Error

--- a/src/components/inputs/DateTimePicker.md
+++ b/src/components/inputs/DateTimePicker.md
@@ -64,7 +64,7 @@ const handleChange = useCallback((d) => {
 
 ### With Custom Input
 
-When defining a custom input, it is important to create a component with accept a ref. React-datepicker offer the possibility to set
+When defining a custom input, it is important to create a component which accept a ref. React-datepicker offer the possibility to set
 a different name for the prop of the input component in charge of accepting the ref object. This prop is `customInputRef`.
 On most of the cases, creating a component with React.forwardRef is sufficient.
 

--- a/src/components/inputs/DateTimePicker.md
+++ b/src/components/inputs/DateTimePicker.md
@@ -4,13 +4,48 @@ SPDX-FileCopyrightText: 2021 Zextras <https://www.zextras.com>
 SPDX-License-Identifier: AGPL-3.0-only
 -->
 
+DateTimePicker is an extension of the picker provided by react-datepicker library. The extension is made to style the
+library component in a ds-style and to give a default input ready to be used.
+
+The props shown here are the one defined for the extension, but it is possible to use all the props of the library itself,
+where not specified here (in this case, they are being overwritten by our component, with a possible different meaning).
+Refer to the official documentation to get a list of them https://github.com/Hacker0x01/react-datepicker
+
+By default, the DateTimePicker provide 2 types of input, a text input and a chip input.
+When using the Input component, it is possible to use some of the props of the library, and they should work out-of-the-box.
+At the contrary, the ChipInput at the moment does not support all the props of react-datepicker, so its behaviour is limited and could differ from the one
+obtainable with the Input.
+
+Examples of the library component are visible here https://reactdatepicker.com/
+
 ### Default
+
+Default are applied also for the react-datepicker props.
 
 ```jsx
 <DateTimePicker label="Date Time Picker" isClearable />
 ```
 
-### Without Time & Custom Date Format
+#### Default with some prop of the original component
+
+React-datepicker props can be set directly in the DateTimePicker
+
+```jsx
+import { useState, useCallback } from 'react';
+const [date, setDate] = useState(new Date());
+const handleChange = useCallback((d) => {
+	setDate(d);
+}, []);
+
+<DateTimePicker
+    label="Date Time Picker"
+    dateFormat="dd/MM/yyyy"
+    preventOpenOnFocus
+    timeIntervals={10}
+/>
+```
+
+### Without time & with custom date format
 
 ```jsx
 import { useState, useCallback } from 'react';
@@ -30,6 +65,16 @@ const handleChange = useCallback((d) => {
 ```
 
 ### With Custom Input
+
+When defining a custom input, it is important to create a component with accept a ref. React-datepicker offer the possibility to set
+a different name for the prop of the input component in charge of accepting the ref object. This prop is `customInputRef`.
+On most of the cases, creating a component with React.forwardRef is sufficient.
+
+React-datetimepicker under the hood takes the customInput (CustomComponent here), clones it, and set some props with internal
+implementations. For example, in order to make the validation of a manual typed value work, you should have a component which
+implements an onChange callback when the value change, following the shape of the event of the `React.ChangeEventHandler<HtmlInputElement>`.
+
+For a better understanding of what react-datepicker does to create the input element, check the method [renderDateInput](https://github.com/Hacker0x01/react-datepicker/blob/10e64e21fddf2b24196d7c17d47670a5be9545f9/src/index.jsx#L1100C6-L1145) of the DatePicker component
 
 ```jsx
 import { useState, forwardRef } from 'react';

--- a/src/components/inputs/DateTimePicker.md
+++ b/src/components/inputs/DateTimePicker.md
@@ -12,9 +12,7 @@ where not specified here (in this case, they are being overwritten by our compon
 Refer to the official documentation to get a list of them https://github.com/Hacker0x01/react-datepicker
 
 By default, the DateTimePicker provide 2 types of input, a text input and a chip input.
-When using the Input component, it is possible to use some of the props of the library, and they should work out-of-the-box.
-At the contrary, the ChipInput at the moment does not support all the props of react-datepicker, so its behaviour is limited and could differ from the one
-obtainable with the Input.
+The behaviour of the two components can differ a bit because of how react-datepicker works under the hood.
 
 Examples of the library component are visible here https://reactdatepicker.com/
 
@@ -71,8 +69,13 @@ a different name for the prop of the input component in charge of accepting the 
 On most of the cases, creating a component with React.forwardRef is sufficient.
 
 React-datetimepicker under the hood takes the customInput (CustomComponent here), clones it, and set some props with internal
-implementations. For example, in order to make the validation of a manual typed value work, you should have a component which
-implements an onChange callback when the value change, following the shape of the event of the `React.ChangeEventHandler<HtmlInputElement>`.
+implementations. It is important, to have react-datepicker works as expected, to propagate all the standard html attributes to the input component.
+The most important ones are
+ * value: set the value of the input
+ * onClick: makes the picker open on click
+ * onChange: perform a validation of the input and set the new value of the picker (and not the input, which is updated by selecting a date/time from the picker)
+ * onFocus: makes the picker open on focus
+ * onKeyDown: update the picker value while typing
 
 For a better understanding of what react-datepicker does to create the input element, check the method [renderDateInput](https://github.com/Hacker0x01/react-datepicker/blob/10e64e21fddf2b24196d7c17d47670a5be9545f9/src/index.jsx#L1100C6-L1145) of the DatePicker component
 

--- a/src/components/inputs/DateTimePicker.test.tsx
+++ b/src/components/inputs/DateTimePicker.test.tsx
@@ -5,11 +5,78 @@
  */
 import React from 'react';
 
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { format, addMonths, startOfMonth } from 'date-fns';
+
 import { render } from '../../test-utils';
+import { ICONS } from '../../testUtils/constants';
 import { DateTimePicker } from './DateTimePicker';
 
 describe('DateTimePicker', () => {
-	test('Value of default input component is validated', () => {
-		render(<DateTimePicker label={''} />);
+	test('Render a DateTimePicker with an input', async () => {
+		const { getByRoleWithIcon } = render(<DateTimePicker label={'The label'} />);
+		expect(screen.getByRole('textbox', { name: /the label/i })).toBeVisible();
+		expect(getByRoleWithIcon('button', { icon: ICONS.datePickerAction })).toBeVisible();
+	});
+
+	test('Click on the input opens the picker', async () => {
+		render(<DateTimePicker label={'The label'} />);
+		userEvent.click(screen.getByTestId(ICONS.datePickerAction));
+		const currentMonthAndYear = format(Date.now(), 'LLLL yyyy');
+		const datePicker = await screen.findByText(currentMonthAndYear);
+		expect(datePicker).toBeVisible();
+	});
+
+	test('Click on the input opens the picker', async () => {
+		render(<DateTimePicker label={'The label'} />);
+		userEvent.click(screen.getByRole('textbox'));
+		const currentMonthAndYear = format(Date.now(), 'LLLL yyyy');
+		const datePicker = await screen.findByText(currentMonthAndYear);
+		expect(datePicker).toBeVisible();
+	});
+
+	test('Click on calendar icon inside the input opens the picker', async () => {
+		const { getByRoleWithIcon } = render(<DateTimePicker label={'The label'} />);
+		userEvent.click(getByRoleWithIcon('button', { icon: ICONS.datePickerAction }));
+		const currentMonthAndYear = format(Date.now(), 'LLLL yyyy');
+		const datePicker = await screen.findByText(currentMonthAndYear);
+		expect(datePicker).toBeVisible();
+	});
+
+	test('Valid value typed in the input is validated and set as date', () => {
+		render(<DateTimePicker label={'Validate input'} />);
+		const inputElement = screen.getByRole('textbox');
+		const now = new Date();
+		const firstOfNextMonth = addMonths(startOfMonth(now), 1);
+		firstOfNextMonth.setHours(now.getHours());
+		firstOfNextMonth.setMinutes(now.getMinutes());
+		const dateString = format(firstOfNextMonth, 'MM/dd/yyyy HH:mm');
+		userEvent.type(inputElement, dateString);
+		userEvent.keyboard('[Enter]');
+		const defaultFormat = 'MMMM d, yyyy h:mm aa';
+		const expectedInputValue = format(firstOfNextMonth, defaultFormat);
+		expect(inputElement).toHaveValue(expectedInputValue);
+	});
+
+	test('If an invalid value is typed in the input with a defaultValue, on select the value of the input is reset to the previous valid date', () => {
+		const now = new Date();
+		render(<DateTimePicker label={'Validate input'} defaultValue={now} />);
+		const inputElement = screen.getByRole('textbox');
+		const defaultFormat = 'MMMM d, yyyy h:mm aa';
+		const defaultInputValue = format(now, defaultFormat);
+		expect(inputElement).toHaveValue(defaultInputValue);
+		userEvent.type(inputElement, 'invalid date format');
+		userEvent.keyboard('[Enter]');
+		expect(inputElement).toHaveValue(defaultInputValue);
+	});
+
+	test('If an invalid value is typed in the input without a default value, on select the value of the input is reset to be empty', () => {
+		render(<DateTimePicker label={'Validate input'} />);
+		const inputElement = screen.getByRole('textbox');
+		expect(inputElement).toHaveValue('');
+		userEvent.type(inputElement, 'invalid date format');
+		userEvent.keyboard('[Enter]');
+		expect(inputElement).toHaveValue('');
 	});
 });

--- a/src/components/inputs/DateTimePicker.test.tsx
+++ b/src/components/inputs/DateTimePicker.test.tsx
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React from 'react';
+
+import { render } from '../../test-utils';
+import { DateTimePicker } from './DateTimePicker';
+
+describe('DateTimePicker', () => {
+	test('Value of default input component is validated', () => {
+		render(<DateTimePicker label={''} />);
+	});
+});

--- a/src/components/inputs/DateTimePicker.test.tsx
+++ b/src/components/inputs/DateTimePicker.test.tsx
@@ -8,75 +8,331 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { format, addMonths, startOfMonth } from 'date-fns';
+import { noop } from 'lodash';
 
 import { render } from '../../test-utils';
 import { ICONS } from '../../testUtils/constants';
-import { DateTimePicker } from './DateTimePicker';
+import { Button } from '../basic/Button';
+import { DateTimePicker, DateTimePickerProps } from './DateTimePicker';
+
+const DEFAULT_DATE_FORMAT = 'MMMM d, yyyy h:mm aa';
 
 describe('DateTimePicker', () => {
-	test('Render a DateTimePicker with an input', async () => {
-		const { getByRoleWithIcon } = render(<DateTimePicker label={'The label'} />);
-		expect(screen.getByRole('textbox', { name: /the label/i })).toBeVisible();
-		expect(getByRoleWithIcon('button', { icon: ICONS.datePickerAction })).toBeVisible();
+	function getDatePickerHeader(date: Date | number): string {
+		return format(date, 'LLLL yyyy');
+	}
+	describe('With default input component', () => {
+		test('Render a DateTimePicker with an input', async () => {
+			const { getByRoleWithIcon } = render(<DateTimePicker label={'The label'} />);
+			expect(screen.getByRole('textbox', { name: /the label/i })).toBeVisible();
+			expect(getByRoleWithIcon('button', { icon: ICONS.datePickerShowAction })).toBeVisible();
+		});
+
+		test('Click on the input opens the picker', async () => {
+			render(<DateTimePicker label={'The label'} />);
+			userEvent.click(screen.getByRole('textbox'));
+			const datePicker = await screen.findByText(getDatePickerHeader(Date.now()));
+			expect(datePicker).toBeVisible();
+		});
+
+		test('Click on calendar icon inside the input opens the picker', async () => {
+			const { getByRoleWithIcon } = render(<DateTimePicker label={'The label'} />);
+			userEvent.click(getByRoleWithIcon('button', { icon: ICONS.datePickerShowAction }));
+			const datePicker = await screen.findByText(getDatePickerHeader(Date.now()));
+			expect(datePicker).toBeVisible();
+		});
+
+		test('Valid value typed in the input is validated and set as date', async () => {
+			render(<DateTimePicker label={'Validate input'} />);
+			const inputElement = screen.getByRole('textbox');
+			const now = new Date();
+			const firstOfNextMonth = addMonths(startOfMonth(now), 1);
+			firstOfNextMonth.setHours(now.getHours());
+			firstOfNextMonth.setMinutes(now.getMinutes());
+			const dateString = format(firstOfNextMonth, 'MM/dd/yyyy HH:mm');
+			userEvent.type(inputElement, dateString);
+			await screen.findByText(getDatePickerHeader(firstOfNextMonth));
+			userEvent.keyboard('[Enter]');
+			const expectedInputValue = format(firstOfNextMonth, DEFAULT_DATE_FORMAT);
+			expect(inputElement).toHaveValue(expectedInputValue);
+		});
+
+		test('If an invalid value is typed in the input with a defaultValue, on select the value of the input is reset to the previous valid date', () => {
+			const now = new Date();
+			render(<DateTimePicker label={'Validate input'} defaultValue={now} />);
+			const inputElement = screen.getByRole('textbox');
+			const defaultInputValue = format(now, DEFAULT_DATE_FORMAT);
+			expect(inputElement).toHaveValue(defaultInputValue);
+			userEvent.type(inputElement, 'invalid date format');
+			userEvent.keyboard('[Enter]');
+			expect(inputElement).toHaveValue(defaultInputValue);
+		});
+
+		test('If an invalid value is typed in the input without a default value, on select the value of the input is reset to be empty', () => {
+			render(<DateTimePicker label={'Validate input'} />);
+			const inputElement = screen.getByRole('textbox');
+			expect(inputElement).toHaveValue('');
+			userEvent.type(inputElement, 'invalid date format');
+			userEvent.keyboard('[Enter]');
+			expect(inputElement).toHaveValue('');
+		});
+
+		test('When a new value is set, onChange prop is called with the new value', () => {
+			const onChangeFn = jest.fn();
+			render(<DateTimePicker label={'label'} onChange={onChangeFn} />);
+			const inputElement = screen.getByRole('textbox');
+			const now = new Date();
+			const dateString = format(now, 'MM/dd/yyyy HH:mm');
+			const parsedDateString = new Date(Date.parse(dateString));
+			userEvent.type(inputElement, dateString);
+			userEvent.keyboard('[Enter]');
+			expect(onChangeFn).toHaveBeenLastCalledWith(parsedDateString);
+		});
+
+		test('When the input is cleared, onChange prop is called with the null value', () => {
+			const onChangeFn = jest.fn();
+			render(
+				<>
+					<DateTimePicker label={'label'} defaultValue={new Date()} onChange={onChangeFn} />
+					<span>Blur</span>
+				</>
+			);
+			const inputElement = screen.getByRole('textbox');
+			userEvent.clear(inputElement);
+			userEvent.keyboard('[Enter]');
+			userEvent.click(screen.getByText('Blur'));
+			expect(onChangeFn).toHaveBeenLastCalledWith(null);
+			expect(inputElement).toHaveValue('');
+		});
+
+		test('When the value is cleared with the clear action, onChange prop is called with the null value and input is cleared', () => {
+			const onChangeFn = jest.fn();
+			const { getByRoleWithIcon } = render(
+				<>
+					<DateTimePicker
+						label={'label'}
+						defaultValue={new Date()}
+						onChange={onChangeFn}
+						isClearable
+					/>
+					<span>Blur</span>
+				</>
+			);
+			const inputElement = screen.getByRole('textbox');
+			userEvent.click(getByRoleWithIcon('button', { icon: ICONS.datePickerClearAction }));
+			userEvent.click(screen.getByText('Blur'));
+			expect(onChangeFn).toHaveBeenLastCalledWith(null);
+			expect(inputElement).toHaveValue('');
+		});
 	});
 
-	test('Click on the input opens the picker', async () => {
-		render(<DateTimePicker label={'The label'} />);
-		userEvent.click(screen.getByTestId(ICONS.datePickerAction));
-		const currentMonthAndYear = format(Date.now(), 'LLLL yyyy');
-		const datePicker = await screen.findByText(currentMonthAndYear);
-		expect(datePicker).toBeVisible();
+	describe('With default chip input component', () => {
+		test('Render a DateTimePicker with a chip input', async () => {
+			const now = new Date();
+			const dateFormat = 'dd/MM/yyyy HH:mm';
+			const nowString = format(now, dateFormat);
+			const { getByRoleWithIcon } = render(
+				<DateTimePicker
+					label={'The label'}
+					enableChips
+					defaultValue={now}
+					dateFormat={dateFormat}
+				/>
+			);
+			expect(screen.getByRole('textbox', { name: /the label/i })).toBeVisible();
+			expect(getByRoleWithIcon('button', { icon: ICONS.datePickerShowAction })).toBeVisible();
+			expect(screen.getByText(nowString)).toBeVisible();
+			expect(getByRoleWithIcon('button', { icon: ICONS.close })).toBeVisible();
+		});
+
+		test('Click on the input opens the picker', async () => {
+			render(<DateTimePicker label={'The label'} enableChips />);
+			userEvent.click(screen.getByRole('textbox'));
+			const datePicker = await screen.findByText(getDatePickerHeader(Date.now()));
+			expect(datePicker).toBeVisible();
+		});
+
+		test('Click on calendar icon inside the input opens the picker', async () => {
+			const { getByRoleWithIcon } = render(<DateTimePicker label={'The label'} enableChips />);
+			userEvent.click(getByRoleWithIcon('button', { icon: ICONS.datePickerShowAction }));
+			const datePicker = await screen.findByText(getDatePickerHeader(Date.now()));
+			expect(datePicker).toBeVisible();
+		});
+
+		test('Selection of a date from the picker creates the chip', async () => {
+			const { getByRoleWithIcon } = render(
+				<DateTimePicker label={'ChipInput DatePicker'} enableChips />
+			);
+			userEvent.click(getByRoleWithIcon('button', { icon: ICONS.datePickerShowAction }));
+			userEvent.click(screen.getAllByText('1')[0]);
+			const expectedDate = new Date();
+			expectedDate.setDate(1);
+			expectedDate.setHours(0, 0, 0, 0);
+			const expectedDateString = format(expectedDate, DEFAULT_DATE_FORMAT);
+			expect(screen.getByText(expectedDateString)).toBeVisible();
+			expect(getByRoleWithIcon('button', { icon: ICONS.close })).toBeVisible();
+		});
+
+		test('Selection of a time from the picker creates the chip', async () => {
+			const { getByRoleWithIcon } = render(
+				<DateTimePicker label={'ChipInput DatePicker'} enableChips />
+			);
+			userEvent.click(getByRoleWithIcon('button', { icon: ICONS.datePickerShowAction }));
+			userEvent.click(screen.getByText('11:00 AM'));
+			const expectedDate = new Date();
+			expectedDate.setHours(11, 0, 0, 0);
+			const expectedDateString = format(expectedDate, DEFAULT_DATE_FORMAT);
+			expect(screen.getByText(expectedDateString)).toBeVisible();
+			expect(getByRoleWithIcon('button', { icon: ICONS.close })).toBeVisible();
+		});
+
+		test('Valid value typed in the input is validated and set as date', async () => {
+			const { getByRoleWithIcon } = render(<DateTimePicker label={'Validate input'} enableChips />);
+			const inputElement = screen.getByRole('textbox');
+			const now = new Date();
+			const firstOfNextMonth = addMonths(startOfMonth(now), 1);
+			firstOfNextMonth.setHours(now.getHours());
+			firstOfNextMonth.setMinutes(now.getMinutes());
+			const dateString = format(firstOfNextMonth, 'MM/dd/yyyy HH:mm');
+			userEvent.type(inputElement, dateString);
+			await screen.findByText(getDatePickerHeader(firstOfNextMonth));
+			userEvent.keyboard('[Enter]');
+			const expectedInputValue = format(firstOfNextMonth, DEFAULT_DATE_FORMAT);
+			expect(screen.getByText(expectedInputValue)).toBeVisible();
+			expect(getByRoleWithIcon('button', { icon: ICONS.close })).toBeVisible();
+		});
+
+		test('Input is disabled if a default value is present', () => {
+			const now = new Date();
+			render(<DateTimePicker label={'Validate input'} defaultValue={now} enableChips />);
+			expect(screen.getByRole('textbox')).toBeDisabled();
+		});
+
+		test('Input becomes disabled if a value is set', () => {
+			render(<DateTimePicker label={'Validate input'} enableChips />);
+			const inputElement = screen.getByRole('textbox');
+			expect(inputElement).toBeEnabled();
+			userEvent.click(inputElement);
+			userEvent.click(screen.getAllByText('1')[0]);
+			expect(inputElement).toBeDisabled();
+		});
+
+		test('If an invalid value is typed, on select the value of the input is reset to be empty', () => {
+			render(<DateTimePicker label={'Validate input'} enableChips />);
+			const inputElement = screen.getByRole('textbox');
+			expect(inputElement).toHaveValue('');
+			userEvent.type(inputElement, 'invalid date format');
+			userEvent.keyboard('[Enter]');
+			expect(inputElement).toHaveValue('');
+		});
+
+		test('When a new value is set, onChange prop is called with the new value', async () => {
+			const onChangeFn = jest.fn();
+			const { getByRoleWithIcon } = render(
+				<>
+					<DateTimePicker label={'label'} onChange={onChangeFn} enableChips />
+					<span>Blur</span>
+				</>
+			);
+			const inputElement = screen.getByRole('textbox');
+			const now = new Date();
+			const firstOfNextMonth = addMonths(startOfMonth(now), 1);
+			firstOfNextMonth.setHours(now.getHours());
+			firstOfNextMonth.setMinutes(now.getMinutes());
+			const dateString = format(firstOfNextMonth, 'MM/dd/yyyy HH:mm');
+			const parsedDateString = new Date(Date.parse(dateString));
+			userEvent.type(inputElement, dateString);
+			await screen.findByText(getDatePickerHeader(firstOfNextMonth));
+			userEvent.keyboard('[Enter]');
+			userEvent.click(screen.getByText('Blur'));
+			expect(onChangeFn).toHaveBeenLastCalledWith(parsedDateString);
+			expect(screen.getByText(format(parsedDateString, DEFAULT_DATE_FORMAT))).toBeVisible();
+			expect(getByRoleWithIcon('button', { icon: ICONS.close })).toBeVisible();
+		});
+
+		test('When the input is cleared, onChange prop is called with the null value', () => {
+			const onChangeFn = jest.fn();
+			const { getByRoleWithIcon, queryByRoleWithIcon } = render(
+				<>
+					<DateTimePicker
+						label={'label'}
+						defaultValue={new Date()}
+						onChange={onChangeFn}
+						enableChips
+					/>
+					<span>Blur</span>
+				</>
+			);
+			const inputElement = screen.getByRole('textbox');
+			userEvent.click(getByRoleWithIcon('button', { icon: ICONS.close }));
+			expect(onChangeFn).toHaveBeenLastCalledWith(null);
+			const now = new Date();
+			const firstOfNextMonth = addMonths(startOfMonth(now), 1);
+			firstOfNextMonth.setHours(now.getHours());
+			firstOfNextMonth.setMinutes(now.getMinutes());
+			const dateString = format(firstOfNextMonth, 'MM/dd/yyyy HH:mm');
+			userEvent.type(inputElement, dateString);
+			userEvent.clear(inputElement);
+			userEvent.click(screen.getByText('Blur'));
+			expect(onChangeFn).toHaveBeenLastCalledWith(null);
+			expect(queryByRoleWithIcon('button', { icon: ICONS.close })).not.toBeInTheDocument();
+			expect(inputElement).toHaveValue('');
+		});
 	});
 
-	test('Click on the input opens the picker', async () => {
-		render(<DateTimePicker label={'The label'} />);
-		userEvent.click(screen.getByRole('textbox'));
-		const currentMonthAndYear = format(Date.now(), 'LLLL yyyy');
-		const datePicker = await screen.findByText(currentMonthAndYear);
-		expect(datePicker).toBeVisible();
-	});
+	describe('With custom input component', () => {
+		const CustomComponent = React.forwardRef<
+			HTMLDivElement,
+			React.ComponentProps<NonNullable<DateTimePickerProps['CustomComponent']>>
+		>(function CustomComponentFn({ value, onClick = noop }, ref) {
+			return <Button onClick={onClick} ref={ref} label={value || 'no value'} />;
+		});
 
-	test('Click on calendar icon inside the input opens the picker', async () => {
-		const { getByRoleWithIcon } = render(<DateTimePicker label={'The label'} />);
-		userEvent.click(getByRoleWithIcon('button', { icon: ICONS.datePickerAction }));
-		const currentMonthAndYear = format(Date.now(), 'LLLL yyyy');
-		const datePicker = await screen.findByText(currentMonthAndYear);
-		expect(datePicker).toBeVisible();
-	});
+		test('Custom component is rendered', () => {
+			render(
+				<DateTimePicker
+					label="picker label"
+					includeTime={false}
+					dateFormat="dd/MM/yyyy"
+					CustomComponent={CustomComponent}
+				/>
+			);
 
-	test('Valid value typed in the input is validated and set as date', () => {
-		render(<DateTimePicker label={'Validate input'} />);
-		const inputElement = screen.getByRole('textbox');
-		const now = new Date();
-		const firstOfNextMonth = addMonths(startOfMonth(now), 1);
-		firstOfNextMonth.setHours(now.getHours());
-		firstOfNextMonth.setMinutes(now.getMinutes());
-		const dateString = format(firstOfNextMonth, 'MM/dd/yyyy HH:mm');
-		userEvent.type(inputElement, dateString);
-		userEvent.keyboard('[Enter]');
-		const defaultFormat = 'MMMM d, yyyy h:mm aa';
-		const expectedInputValue = format(firstOfNextMonth, defaultFormat);
-		expect(inputElement).toHaveValue(expectedInputValue);
-	});
+			expect(screen.getByRole('button', { name: /no value/i })).toBeVisible();
+			expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+			expect(screen.queryByText(/picker label/i)).not.toBeInTheDocument();
+		});
 
-	test('If an invalid value is typed in the input with a defaultValue, on select the value of the input is reset to the previous valid date', () => {
-		const now = new Date();
-		render(<DateTimePicker label={'Validate input'} defaultValue={now} />);
-		const inputElement = screen.getByRole('textbox');
-		const defaultFormat = 'MMMM d, yyyy h:mm aa';
-		const defaultInputValue = format(now, defaultFormat);
-		expect(inputElement).toHaveValue(defaultInputValue);
-		userEvent.type(inputElement, 'invalid date format');
-		userEvent.keyboard('[Enter]');
-		expect(inputElement).toHaveValue(defaultInputValue);
-	});
+		test('On click is passed to the component to open the picker', () => {
+			render(
+				<DateTimePicker
+					label="picker label"
+					includeTime={false}
+					dateFormat="dd/MM/yyyy"
+					CustomComponent={CustomComponent}
+				/>
+			);
 
-	test('If an invalid value is typed in the input without a default value, on select the value of the input is reset to be empty', () => {
-		render(<DateTimePicker label={'Validate input'} />);
-		const inputElement = screen.getByRole('textbox');
-		expect(inputElement).toHaveValue('');
-		userEvent.type(inputElement, 'invalid date format');
-		userEvent.keyboard('[Enter]');
-		expect(inputElement).toHaveValue('');
+			userEvent.click(screen.getByRole('button'));
+			expect(screen.getByText(getDatePickerHeader(Date.now()))).toBeVisible();
+		});
+
+		test('Updated value is passed to the custom component', () => {
+			const dateFormat = 'dd/MM/yyyy';
+			render(
+				<DateTimePicker
+					label="picker label"
+					includeTime={false}
+					dateFormat={dateFormat}
+					CustomComponent={CustomComponent}
+				/>
+			);
+
+			userEvent.click(screen.getByRole('button'));
+			userEvent.click(screen.getAllByText('1')[0]);
+			expect(
+				screen.getByRole('button', { name: format(startOfMonth(Date.now()), dateFormat) })
+			).toBeVisible();
+		});
 	});
 });

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -34,7 +34,7 @@ const queryAllByRoleWithIcon: GetAllBy<[ByRoleMatcher, ByRoleWithIconOptions]> =
 ) =>
 	filter(
 		screen.queryAllByRole('button', options),
-		(element) => within(element).queryByTestId(`icon: ${icon}`) !== null
+		(element) => within(element).queryByTestId(icon) !== null
 	);
 const getByRoleWithIconMultipleError = (
 	container: Element | null,

--- a/src/testUtils/constants.ts
+++ b/src/testUtils/constants.ts
@@ -6,5 +6,6 @@
 export const ICONS = {
 	checkboxOn: 'icon: CheckmarkSquare',
 	checkboxOff: 'icon: Square',
-	close: 'icon: Close'
+	close: 'icon: Close',
+	datePickerAction: 'icon: CalendarOutline'
 };

--- a/src/testUtils/constants.ts
+++ b/src/testUtils/constants.ts
@@ -7,5 +7,6 @@ export const ICONS = {
 	checkboxOn: 'icon: CheckmarkSquare',
 	checkboxOff: 'icon: Square',
 	close: 'icon: Close',
-	datePickerAction: 'icon: CalendarOutline'
+	datePickerShowAction: 'icon: CalendarOutline',
+	datePickerClearAction: 'icon: CloseOutline'
 };

--- a/src/testUtils/constants.ts
+++ b/src/testUtils/constants.ts
@@ -5,5 +5,6 @@
  */
 export const ICONS = {
 	checkboxOn: 'icon: CheckmarkSquare',
-	checkboxOff: 'icon: Square'
+	checkboxOff: 'icon: Square',
+	close: 'icon: Close'
 };


### PR DESCRIPTION
I managed to update the behaviour of the picker with both an input or a chip input as input component, so that they accept a typed value, which is validated by react-datepicker library and set as value if it is considered valid.

This means that:

- if the user writes something which isn’t in any way transformed in a date, the input is considered invalid and the input is reset with the previous valid value
    - if the previous valid value was a date, that date is set again
    - if the previous valid value was not set, the input is reset to be empty
 - if the user writes something which at some point was transformable in a date (react-datepicker library is in charge of this transformation tentative), the last valid transformation value is set as new value.

To explain it differently, in order to have the input validated, the calendar picker needs to be open while typing. react-datepicker under the hood tries to convert the typed string in a date, and updates the calendar picker to show the date the user is typing as pre-selected. Because of this check,a string like ‘112’, which is not a date as it is, is converted in a valid date (november 1st, current year in a MM/dd/yyyy like format), because while typing the first characters ‘11’, react-datepicker converted those two numbers in the month. For the same reason, if the format is dd/MM/yyyy, and the user types ‘112’, the date pre-selected is 11th, current month, current year.

Another fix I made is specific to the usage with a chip input: when a date is set, the input of the chip input becomes disabled. In order to change the date, the user can:

- remove the previous chip with the close action of the chip, then select a new date from the calendar picker or type a new date in the input, which becomes enabled again when the chip is removed.
- select a new date from the calendar picker, which is opened immediately when the chip input is clicked. The new chip will then replace the previous one, as the component was already doing.

When removing the chip with the close action, the last valid value is considered “unset”, so if the user writes something totally wrong, the input will be reset to be empty (following the rules described before).

Finally, as before the DateTimePicker allows to set a custom input component. In order to have the input validated, the dev needs to set a component which accepts a ref, and which propagates the required props to the rendered custom component. For more info about this, refer to the docs.

refs: CDS-140