### PR TITLE
fix(CustomModal): do not prevent default behavior of click inside modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
 				"husky": "^8.0.3",
 				"is-ci": "3.0.1",
 				"jest": "26.6.3",
+				"jest-fail-on-console": "^3.1.1",
 				"jest-junit": "13.0.0",
 				"jest-styled-components": "7.1.1",
 				"lodash": "^4.17.21",
@@ -14244,6 +14245,85 @@
 			}
 		},
 		"node_modules/jest-environment-node/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-fail-on-console": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/jest-fail-on-console/-/jest-fail-on-console-3.1.1.tgz",
+			"integrity": "sha512-g9HGhKcWOz8lHeZhLCXGg+RD/7upngiKkkBrHimsO/tGB0qi++QZffOgybjeI2bDW1qgdFiJJEG6t/WeTlfmOw==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.1.0"
+			}
+		},
+		"node_modules/jest-fail-on-console/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/jest-fail-on-console/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/jest-fail-on-console/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/jest-fail-on-console/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/jest-fail-on-console/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-fail-on-console/node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
@@ -33663,6 +33743,66 @@
 						"is-ci": "^2.0.0",
 						"micromatch": "^4.0.2"
 					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"jest-fail-on-console": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/jest-fail-on-console/-/jest-fail-on-console-3.1.1.tgz",
+			"integrity": "sha512-g9HGhKcWOz8lHeZhLCXGg+RD/7upngiKkkBrHimsO/tGB0qi++QZffOgybjeI2bDW1qgdFiJJEG6t/WeTlfmOw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.1.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
 		"husky": "^8.0.3",
 		"is-ci": "3.0.1",
 		"jest": "26.6.3",
+		"jest-fail-on-console": "^3.1.1",
 		"jest-junit": "13.0.0",
 		"jest-styled-components": "7.1.1",
 		"lodash": "^4.17.21",

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -5,3 +5,9 @@
  */
 export const INPUT_BACKGROUND_COLOR = 'gray5';
 export const INPUT_DIVIDER_COLOR = 'gray3';
+
+export const TIMERS = {
+	MODAL: {
+		DELAY_OPEN: 1
+	}
+};

--- a/src/components/feedback/CustomModal.test.tsx
+++ b/src/components/feedback/CustomModal.test.tsx
@@ -35,7 +35,7 @@ const ModalTester = ({ children, ...props }: CustomModalProps): React.JSX.Elemen
 };
 
 describe('Custom Modal', () => {
-	test('Render Modal', () => {
+	test('Render Modal', async () => {
 		render(<ModalTester />);
 
 		const button = screen.getByRole('button', { name: /trigger modal/i });
@@ -44,9 +44,8 @@ describe('Custom Modal', () => {
 		expect(screen.queryByText('Lorem ipsum dolor sit amet.')).not.toBeInTheDocument();
 
 		userEvent.click(button);
-
-		expect(screen.getByText('My Title')).toBeInTheDocument();
-		expect(screen.getByText('Lorem ipsum dolor sit amet.')).toBeInTheDocument();
+		await waitFor(() => expect(screen.getByText('My Title')).toBeVisible());
+		expect(screen.getByText('Lorem ipsum dolor sit amet.')).toBeVisible();
 		expect(button).toBeInTheDocument();
 	});
 
@@ -55,26 +54,13 @@ describe('Custom Modal', () => {
 		render(<ModalTester onClick={onClick} />);
 
 		const button = screen.getByRole('button', { name: /trigger modal/i });
-		expect(button).toBeInTheDocument();
 		expect(screen.queryByText('My Title')).not.toBeInTheDocument();
-		expect(screen.queryByText('Lorem ipsum dolor sit amet.')).not.toBeInTheDocument();
-
 		userEvent.click(button);
-
-		// wait for listeners to be registered
-		await waitFor(
-			() =>
-				new Promise((resolve) => {
-					setTimeout(resolve, 1);
-				})
-		);
-		expect(screen.getByText('My Title')).toBeVisible();
-		expect(screen.getByText('Lorem ipsum dolor sit amet.')).toBeVisible();
+		await waitFor(() => expect(screen.getByText('My Title')).toBeVisible());
 		const overlayElement = screen.getByTestId('modal');
 		expect(overlayElement).toBeVisible();
 		userEvent.click(overlayElement);
 		expect(screen.queryByText('My Title')).not.toBeInTheDocument();
-		expect(screen.queryByText('Lorem ipsum dolor sit amet.')).not.toBeInTheDocument();
 		expect(onClick).not.toHaveBeenCalled();
 	});
 
@@ -85,22 +71,10 @@ describe('Custom Modal', () => {
 		const button = screen.getByRole('button', { name: /trigger modal/i });
 		expect(button).toBeInTheDocument();
 		expect(screen.queryByText('My Title')).not.toBeInTheDocument();
-		expect(screen.queryByText('Lorem ipsum dolor sit amet.')).not.toBeInTheDocument();
-
 		userEvent.click(button);
-
-		// wait for listeners to be registered
-		await waitFor(
-			() =>
-				new Promise((resolve) => {
-					setTimeout(resolve, 1);
-				})
-		);
-		expect(screen.getByText('My Title')).toBeVisible();
-		expect(screen.getByText('Lorem ipsum dolor sit amet.')).toBeVisible();
+		await waitFor(() => expect(screen.getByText('My Title')).toBeVisible());
 		userEvent.click(screen.getByText('My Title'));
 		expect(screen.getByText('My Title')).toBeVisible();
-		expect(screen.getByText('Lorem ipsum dolor sit amet.')).toBeVisible();
 		expect(onClick).toHaveBeenCalled();
 	});
 
@@ -117,20 +91,14 @@ describe('Custom Modal', () => {
 			</ModalTester>
 		);
 		userEvent.click(screen.getByRole('button'));
-		await waitFor(
-			() =>
-				new Promise((resolve) => {
-					setTimeout(resolve, 1);
-				})
-		);
 		userEvent.click(screen.getByRole('link'));
 		await waitFor(
 			() =>
 				new Promise((resolve) => {
+					// wait for the navigation callback of the jsdom hyperlink implementation to be called
 					setTimeout(resolve, 1);
 				})
 		);
-
 		expect(errors).toEqual([
 			expect.stringContaining('Error: Not implemented: navigation (except hash changes)')
 		]);

--- a/src/components/feedback/CustomModal.tsx
+++ b/src/components/feedback/CustomModal.tsx
@@ -6,18 +6,17 @@
 
 /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
 import React, {
-	useState,
 	useEffect,
 	useMemo,
 	useCallback,
 	useRef,
 	useContext,
-	HTMLAttributes
+	HTMLAttributes,
+	useState
 } from 'react';
 
-import { ThemeContext } from 'styled-components';
+import { DefaultTheme, ThemeContext } from 'styled-components';
 
-import { ModalProps } from './Modal';
 import {
 	getScrollbarSize,
 	isBodyOverflowing,
@@ -27,24 +26,38 @@ import {
 } from './modal-components/ModalComponents';
 import { useCombinedRefs } from '../../hooks/useCombinedRefs';
 import { KeyboardPreset, useKeyboard } from '../../hooks/useKeyboard';
+import { TIMERS } from '../constants';
 import { Portal } from '../utilities/Portal';
 import { Transition } from '../utilities/Transition';
 
-type PickedModal = Pick<
-	ModalProps,
-	| 'background'
-	| 'size'
-	| 'open'
-	| 'onClose'
-	| 'zIndex'
-	| 'minHeight'
-	| 'maxHeight'
-	| 'disablePortal'
-	| 'children'
->;
+type BareModalProps = {
+	/** Modal background */
+	background?: string | keyof DefaultTheme['palette'];
+	/** Modal size */
+	size?: 'extrasmall' | 'small' | 'medium' | 'large';
+	/** Boolean to show the modal */
+	open?: boolean;
+	/** Css property to handle the stack order of multiple modals */
+	zIndex?: number;
+	/** min height of the modal */
+	minHeight?: string;
+	/** max height of the modal */
+	maxHeight?: string;
+	/** Flag to disable the Portal implementation */
+	disablePortal?: boolean;
+	/** Content of the modal */
+	children?: React.ReactNode | React.ReactNode[];
+	/** Callback to close the Modal */
+	onClose?: (event: React.MouseEvent | KeyboardEvent) => void;
+	/**
+	 * The window where to insert the Portal's children.
+	 * The default value is 'windowObj' obtained from the ThemContext.
+	 * */
+	containerWindow?: Window;
+};
 
-type CustomModalProps = PickedModal &
-	Omit<HTMLAttributes<HTMLDivElement>, keyof PickedModal | 'title'>;
+type CustomModalProps = BareModalProps &
+	Omit<HTMLAttributes<HTMLDivElement>, keyof BareModalProps | 'title'>;
 
 const CustomModal = React.forwardRef<HTMLDivElement, CustomModalProps>(function ModalFn(
 	{
@@ -58,12 +71,14 @@ const CustomModal = React.forwardRef<HTMLDivElement, CustomModalProps>(function 
 		maxHeight,
 		zIndex = 999,
 		onClick,
+		containerWindow,
 		...rest
 	},
 	ref
 ) {
 	const [delayedOpen, setDelayedOpen] = useState(false);
-	const { windowObj } = useContext(ThemeContext);
+	const { windowObj: themeWindowObj } = useContext(ThemeContext);
+	const windowObj = containerWindow ?? themeWindowObj;
 
 	const modalRef = useCombinedRefs<HTMLDivElement>(ref);
 	const modalContentRef = useRef<HTMLDivElement>(null);
@@ -145,14 +160,16 @@ const CustomModal = React.forwardRef<HTMLDivElement, CustomModalProps>(function 
 	}, [open, onStartSentinelFocus, onEndSentinelFocus, windowObj]);
 
 	useEffect(() => {
-		const timeout = setTimeout(() => setDelayedOpen(open), 1);
+		// delay the open of the modal after the show of the portal
+		// in order to make the transition visible
+		const timeout = setTimeout(() => setDelayedOpen(open), TIMERS.MODAL.DELAY_OPEN);
 		return (): void => {
 			clearTimeout(timeout);
 		};
 	}, [open]);
 
 	return (
-		<Portal show={open} disablePortal={disablePortal}>
+		<Portal show={open} disablePortal={disablePortal} container={windowObj.document.body}>
 			<ModalContainer
 				ref={modalRef}
 				open={delayedOpen}

--- a/src/components/feedback/CustomModal.tsx
+++ b/src/components/feedback/CustomModal.tsx
@@ -151,12 +151,6 @@ const CustomModal = React.forwardRef<HTMLDivElement, CustomModalProps>(function 
 		};
 	}, [open]);
 
-	const modalWrapperClickHandler = useCallback<React.MouseEventHandler>((e) => {
-		if (e) {
-			e.preventDefault();
-		}
-	}, []);
-
 	return (
 		<Portal show={open} disablePortal={disablePortal}>
 			<ModalContainer
@@ -170,7 +164,7 @@ const CustomModal = React.forwardRef<HTMLDivElement, CustomModalProps>(function 
 			>
 				<div tabIndex={0} ref={startSentinelRef} />
 				<Transition type="scale-in" apply={delayedOpen}>
-					<ModalWrapper onClick={modalWrapperClickHandler}>
+					<ModalWrapper>
 						<ModalContent
 							ref={modalContentRef}
 							background={background}

--- a/src/components/feedback/Modal.test.tsx
+++ b/src/components/feedback/Modal.test.tsx
@@ -36,18 +36,16 @@ const ModalTester = ({ children, ...props }: ModalProps): React.JSX.Element => {
 };
 
 describe('Modal', () => {
-	test('Render Modal', () => {
+	test('Render Modal', async () => {
 		render(<ModalTester />);
 
 		const button = screen.getByRole('button', { name: /trigger modal/i });
 		expect(button).toBeInTheDocument();
 		expect(screen.queryByText('My Title')).not.toBeInTheDocument();
 		expect(screen.queryByText('Lorem ipsum dolor sit amet.')).not.toBeInTheDocument();
-
 		userEvent.click(button);
-
-		expect(screen.getByText('My Title')).toBeInTheDocument();
-		expect(screen.getByText('Lorem ipsum dolor sit amet.')).toBeInTheDocument();
+		await waitFor(() => expect(screen.getByText('My Title')).toBeVisible());
+		expect(screen.getByText('Lorem ipsum dolor sit amet.')).toBeVisible();
 		expect(button).toBeInTheDocument();
 	});
 
@@ -58,24 +56,12 @@ describe('Modal', () => {
 		const button = screen.getByRole('button', { name: /trigger modal/i });
 		expect(button).toBeInTheDocument();
 		expect(screen.queryByText('My Title')).not.toBeInTheDocument();
-		expect(screen.queryByText('Lorem ipsum dolor sit amet.')).not.toBeInTheDocument();
-
 		userEvent.click(button);
-
-		// wait for listeners to be registered
-		await waitFor(
-			() =>
-				new Promise((resolve) => {
-					setTimeout(resolve, 1);
-				})
-		);
-		expect(screen.getByText('My Title')).toBeVisible();
-		expect(screen.getByText('Lorem ipsum dolor sit amet.')).toBeVisible();
+		await waitFor(() => expect(screen.getByText('My Title')).toBeVisible());
 		const overlayElement = screen.getByTestId('modal');
 		expect(overlayElement).toBeVisible();
 		userEvent.click(overlayElement);
 		expect(screen.queryByText('My Title')).not.toBeInTheDocument();
-		expect(screen.queryByText('Lorem ipsum dolor sit amet.')).not.toBeInTheDocument();
 		expect(onClick).not.toHaveBeenCalled();
 	});
 
@@ -86,22 +72,10 @@ describe('Modal', () => {
 		const button = screen.getByRole('button', { name: /trigger modal/i });
 		expect(button).toBeInTheDocument();
 		expect(screen.queryByText('My Title')).not.toBeInTheDocument();
-		expect(screen.queryByText('Lorem ipsum dolor sit amet.')).not.toBeInTheDocument();
-
 		userEvent.click(button);
-
-		// wait for listeners to be registered
-		await waitFor(
-			() =>
-				new Promise((resolve) => {
-					setTimeout(resolve, 1);
-				})
-		);
-		expect(screen.getByText('My Title')).toBeVisible();
-		expect(screen.getByText('Lorem ipsum dolor sit amet.')).toBeVisible();
+		await waitFor(() => expect(screen.getByText('My Title')).toBeVisible());
 		userEvent.click(screen.getByText('My Title'));
 		expect(screen.getByText('My Title')).toBeVisible();
-		expect(screen.getByText('Lorem ipsum dolor sit amet.')).toBeVisible();
 		expect(onClick).toHaveBeenCalled();
 	});
 
@@ -118,20 +92,14 @@ describe('Modal', () => {
 			</ModalTester>
 		);
 		userEvent.click(screen.getByRole('button'));
-		await waitFor(
-			() =>
-				new Promise((resolve) => {
-					setTimeout(resolve, 1);
-				})
-		);
 		userEvent.click(screen.getByRole('link'));
 		await waitFor(
 			() =>
 				new Promise((resolve) => {
+					// wait for the navigation callback of the jsdom hyperlink implementation to be called
 					setTimeout(resolve, 1);
 				})
 		);
-
 		expect(errors).toEqual([
 			expect.stringContaining('Error: Not implemented: navigation (except hash changes)')
 		]);

--- a/src/components/feedback/Modal.tsx
+++ b/src/components/feedback/Modal.tsx
@@ -6,34 +6,16 @@
 
 /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
 
-import React, {
-	HTMLAttributes,
-	useCallback,
-	useContext,
-	useEffect,
-	useMemo,
-	useRef,
-	useState
-} from 'react';
+import React, { HTMLAttributes, useCallback, useContext, useRef } from 'react';
 
 import { noop } from 'lodash';
-import { DefaultTheme, ThemeContext } from 'styled-components';
+import { ThemeContext } from 'styled-components';
 
+import { CustomModal, CustomModalProps } from './CustomModal';
 import { ModalBody } from './modal-components/ModalBody';
-import {
-	getScrollbarSize,
-	isBodyOverflowing,
-	ModalContainer,
-	ModalContent,
-	ModalWrapper
-} from './modal-components/ModalComponents';
 import { ModalFooter, ModalFooterProps } from './modal-components/ModalFooter';
 import { ModalHeader } from './modal-components/ModalHeader';
-import { useCombinedRefs } from '../../hooks/useCombinedRefs';
-import { KeyboardPreset, useKeyboard } from '../../hooks/useKeyboard';
 import { Divider } from '../layout/Divider';
-import { Portal } from '../utilities/Portal';
-import { Transition } from '../utilities/Transition';
 
 function copyToClipboard(node: HTMLDivElement | null, windowObj: Window): void {
 	const el = windowObj.document.createElement('textarea');
@@ -46,47 +28,24 @@ function copyToClipboard(node: HTMLDivElement | null, windowObj: Window): void {
 	}
 }
 
-type ModalProps = Omit<ModalFooterProps, 'errorActionLabel' | 'onErrorAction'> & {
-	/** Modal background */
-	background?: string | keyof DefaultTheme['palette'];
-	/** Modal title */
-	title?: string | React.ReactElement;
-	/** Modal size */
-	size?: 'extrasmall' | 'small' | 'medium' | 'large';
-	/** Boolean to show the modal */
-	open?: boolean;
-	/** Hide the footer completely */
-	hideFooter?: boolean;
-	/** Show icon to close Modal */
-	showCloseIcon?: boolean;
-	/** Css property to handle the stack order of multiple modals */
-	zIndex?: number;
-	/** min height of the modal */
-	minHeight?: string;
-	/** max height of the modal */
-	maxHeight?: string;
-	/** Flag to disable the Portal implementation */
-	disablePortal?: boolean;
-	/** Content of the modal */
-	children?: React.ReactNode | React.ReactNode[];
-	/**
-	 * The window where to insert the Portal's children.
-	 * The default value is 'windowObj' obtained from the ThemContext.
-	 * */
-	containerWindow?: Window;
-	/** Label for copy button in the Error Modal */
-	copyLabel?: ModalFooterProps['errorActionLabel'];
-	/** Close icon tooltip label */
-	closeIconTooltip?: string;
-} & Omit<HTMLAttributes<HTMLDivElement>, 'title'>;
+type ModalProps = CustomModalProps &
+	Omit<ModalFooterProps, 'errorActionLabel' | 'onErrorAction'> & {
+		/** Modal title */
+		title?: string | React.ReactElement;
+		/** Hide the footer completely */
+		hideFooter?: boolean;
+		/** Show icon to close Modal */
+		showCloseIcon?: boolean;
+		/** Label for copy button in the Error Modal */
+		copyLabel?: ModalFooterProps['errorActionLabel'];
+		/** Close icon tooltip label */
+		closeIconTooltip?: string;
+	} & Omit<HTMLAttributes<HTMLDivElement>, 'title'>;
 
 const Modal = React.forwardRef<HTMLDivElement, ModalProps>(function ModalFn(
 	{
-		background = 'gray6',
 		type = 'default',
 		title: Title,
-		size = 'small',
-		open = false,
 		centered = false,
 		onConfirm,
 		confirmLabel = 'OK',
@@ -100,173 +59,58 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>(function ModalFn(
 		customFooter,
 		hideFooter = false,
 		showCloseIcon = true,
-		minHeight,
-		maxHeight,
 		children,
 		containerWindow,
-		disablePortal = false,
-		zIndex = 999,
-		onClick,
 		closeIconTooltip,
 		...rest
 	},
 	ref
 ) {
-	const [delayedOpen, setDelayedOpen] = useState(false);
 	const { windowObj: themeWindowObj } = useContext(ThemeContext);
 	const windowObj = containerWindow ?? themeWindowObj;
 
-	const innerRef = useRef<HTMLDivElement | null>(null);
-	const modalRef = useCombinedRefs<HTMLDivElement>(ref, innerRef);
-	const modalContentRef = useRef<HTMLDivElement>(null);
 	const modalBodyRef = useRef<HTMLDivElement | null>(null);
-	const startSentinelRef = useRef<HTMLDivElement | null>(null);
-	const endSentinelRef = useRef<HTMLDivElement | null>(null);
 
-	const onBackdropClick = useCallback(
-		(e: Event | React.SyntheticEvent) => {
-			if (e) {
-				e.stopPropagation();
-			}
-			if (
-				!e.defaultPrevented &&
-				modalContentRef.current &&
-				e.target instanceof Node &&
-				!modalContentRef.current.contains(e.target) &&
-				onClose
-			) {
-				onClose(e);
-			}
-		},
-		[onClose]
-	);
 	const onCopyClipboard = useCallback(
 		() => copyToClipboard(modalBodyRef.current, windowObj),
 		[windowObj]
 	);
 
-	const onStartSentinelFocus = useCallback(() => {
-		if (modalContentRef.current) {
-			const nodeList = modalContentRef.current.querySelectorAll<HTMLElement>('[tabindex]');
-			nodeList[nodeList.length - 1].focus();
-		}
-	}, []);
-	const onEndSentinelFocus = useCallback(() => {
-		if (modalContentRef.current != null) {
-			modalContentRef.current.querySelector<HTMLElement>('[tabindex]')?.focus();
-		}
-	}, []);
-
-	const escapeEvent = useMemo<KeyboardPreset>(
-		() => [{ type: 'keydown', callback: onClose || noop, keys: ['Escape'], modifier: false }],
-		[onClose]
-	);
-	useKeyboard(modalRef, escapeEvent);
-
-	useEffect(() => {
-		if (open) {
-			const defaultOverflowY = windowObj.document.body.style.overflowY;
-			const defaultPaddingRight = windowObj.document.body.style.paddingRight;
-
-			windowObj.document.body.style.overflowY = 'hidden';
-			modalRef.current != null &&
-				isBodyOverflowing(modalRef, windowObj) &&
-				(windowObj.document.body.style.paddingRight = `${getScrollbarSize(windowObj)}px`);
-
-			return (): void => {
-				windowObj.document.body.style.overflowY = defaultOverflowY;
-				windowObj.document.body.style.paddingRight = defaultPaddingRight;
-			};
-		}
-		return (): void => undefined;
-	}, [modalRef, open, windowObj]);
-
-	useEffect(() => {
-		const focusedElement = windowObj.document.activeElement;
-
-		if (open) {
-			modalContentRef.current?.focus();
-			startSentinelRef.current?.addEventListener('focus', onStartSentinelFocus);
-			endSentinelRef.current?.addEventListener('focus', onEndSentinelFocus);
-		}
-		const startSentinelRefSave = startSentinelRef.current;
-		const endSentinelRefSave = endSentinelRef.current;
-		return (): void => {
-			startSentinelRefSave &&
-				startSentinelRefSave.removeEventListener('focus', onStartSentinelFocus);
-			endSentinelRefSave && endSentinelRefSave.removeEventListener('focus', onEndSentinelFocus);
-			open && focusedElement && (focusedElement as HTMLElement).focus();
-		};
-	}, [open, onStartSentinelFocus, onEndSentinelFocus, windowObj]);
-
-	useEffect(() => {
-		const timeout = setTimeout(() => setDelayedOpen(open), 1);
-
-		return (): void => {
-			clearTimeout(timeout);
-		};
-	}, [open]);
-
 	return (
-		<Portal show={open} disablePortal={disablePortal} container={windowObj.document.body}>
-			<ModalContainer
-				ref={modalRef}
-				open={delayedOpen}
-				mounted={open}
-				onClick={onBackdropClick}
-				zIndex={zIndex}
-				data-testid="modal"
-				{...rest}
-			>
-				<div tabIndex={0} ref={startSentinelRef} />
-				<Transition type="scale-in" apply={delayedOpen}>
-					<ModalWrapper>
-						<ModalContent
-							ref={modalContentRef}
-							background={background}
-							$size={size}
-							minHeight={minHeight}
-							maxHeight={maxHeight}
-							onClick={onClick}
-						>
-							<ModalHeader
-								centered={centered}
-								type={type}
-								title={Title}
-								showCloseIcon={showCloseIcon}
-								onClose={onClose}
-								closeIconTooltip={closeIconTooltip}
-							/>
-							<Divider />
-							<ModalBody centered={centered} ref={modalBodyRef}>
-								{children}
-							</ModalBody>
-							{!hideFooter && (
-								<>
-									<Divider />
-									<ModalFooter
-										centered={centered}
-										customFooter={customFooter}
-										type={type}
-										optionalFooter={optionalFooter}
-										confirmLabel={confirmLabel}
-										confirmColor={confirmColor}
-										dismissLabel={dismissLabel}
-										onConfirm={onConfirm}
-										onClose={onClose}
-										onSecondaryAction={onSecondaryAction}
-										secondaryActionLabel={secondaryActionLabel}
-										onErrorAction={onCopyClipboard}
-										errorActionLabel={copyLabel}
-									/>
-								</>
-							)}
-						</ModalContent>
-					</ModalWrapper>
-				</Transition>
-				<div tabIndex={0} ref={endSentinelRef} />
-			</ModalContainer>
-		</Portal>
+		<CustomModal onClose={onClose} ref={ref} {...rest}>
+			<ModalHeader
+				centered={centered}
+				type={type}
+				title={Title}
+				showCloseIcon={showCloseIcon}
+				onClose={onClose}
+				closeIconTooltip={closeIconTooltip}
+			/>
+			<Divider />
+			<ModalBody centered={centered} ref={modalBodyRef}>
+				{children}
+			</ModalBody>
+			{!hideFooter && (
+				<>
+					<Divider />
+					<ModalFooter
+						centered={centered}
+						customFooter={customFooter}
+						type={type}
+						optionalFooter={optionalFooter}
+						confirmLabel={confirmLabel}
+						confirmColor={confirmColor}
+						dismissLabel={dismissLabel}
+						onConfirm={onConfirm}
+						onClose={onClose}
+						onSecondaryAction={onSecondaryAction}
+						secondaryActionLabel={secondaryActionLabel}
+						onErrorAction={onCopyClipboard}
+						errorActionLabel={copyLabel}
+					/>
+				</>
+			)}
+		</CustomModal>
 	);
 });
 

--- a/src/components/utilities/Catcher.test.tsx
+++ b/src/components/utilities/Catcher.test.tsx
@@ -28,7 +28,7 @@ describe('Catcher', () => {
 	});
 
 	test('Render a component with an error', () => {
-		jest.spyOn(console, 'error');
+		jest.spyOn(console, 'error').mockImplementation();
 		const onError = jest.fn();
 		render(
 			<Catcher onError={onError}>

--- a/src/jest-env-setup.ts
+++ b/src/jest-env-setup.ts
@@ -6,6 +6,12 @@
 
 import '@testing-library/jest-dom/extend-expect';
 import { act } from '@testing-library/react';
+import failOnConsole from 'jest-fail-on-console';
+
+failOnConsole({
+	shouldFailOnError: true,
+	shouldFailOnWarn: true
+});
 
 beforeAll(() => {
 	Object.defineProperty(window, 'matchMedia', {


### PR DESCRIPTION
* fix(CustomModal): do not prevent default behavior of click inside modal 

  By blinldy preventing default behavior on click, basic html elements
  like the anchor, in which the click is left to be the default one,
  stop working.

  Remove the prevention of the default behaviour from the custom modal,
  and leave the external user in charge of preventing what needs to be prevented.

* test: add jest-fail-on-console to make test fail on console errors

* test(Modal, CustomModal): test default behaviour for anchor tag

* refactor(Modal,CustomModal): merge implementations

  Since the implementation of the modal is the same, use a CustomModal also to render
  a standard Modal, in order to remove the duplicated code and prevent differences
  in the two components.

  Remove the timers where possible

  Use the containerWindow body of the container window if provided


refs: CDS-102