### PR TITLE
fix(ListV2): firing onListBottom event when browser zoom is different…

### DIFF
--- a/src/components/display/ListV2.tsx
+++ b/src/components/display/ListV2.tsx
@@ -49,7 +49,7 @@ const BottomElement: React.VFC<BottomElementProps> = ({ listRef, onVisible }) =>
 			onVisible();
 		}
 	}, [inView, onVisible]);
-	return <div ref={ref} />;
+	return <div ref={ref} style={{ minHeight: '4px', minWidth: '1px' }} />;
 };
 
 interface ListV2Props extends ContainerProps {


### PR DESCRIPTION
Increase the minimum size of the BottomElement of the ListV2

refs: CDS-191