### PR TITLE
feat(Dropdown): close dropdown when user scrolls outside the component

### DIFF
--- a/src/components/display/Dropdown.test.tsx
+++ b/src/components/display/Dropdown.test.tsx
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 
-import { act } from '@testing-library/react';
+import { act, fireEvent } from '@testing-library/react';
 
 import { Dropdown, DropdownItem } from './Dropdown';
 import { setup, within, screen, UserEvent } from '../../test-utils';
@@ -599,6 +599,47 @@ describe('Dropdown', () => {
 			jest.advanceTimersByTime(TIMERS.DROPDOWN.CLOSE_NESTED);
 		});
 		expect(findDropdownItem('item 5')).toHaveFocus();
+	});
+
+	it('should close dropdown when scrolling outside of the dropdown', async () => {
+		const items = [
+			{ id: '1', label: 'Item 1' },
+			{ id: '2', label: 'Item 2' }
+		] satisfies DropdownItem[];
+		const { user } = setup(
+			<div data-testid="outside-component">
+				<Dropdown items={items} placement="bottom-end">
+					<Button icon="ArrowDown" label="Create" onClick={jest.fn()} />
+				</Dropdown>
+			</div>
+		);
+
+		await user.click(screen.getByRole('button'));
+		expect(screen.getByText(items[0].label)).toBeVisible();
+
+		fireEvent.scroll(screen.getByTestId('outside-component'));
+
+		expect(screen.queryByText(items[0].label)).not.toBeInTheDocument();
+	});
+
+	it('should not close dropdown when scrolling inside the dropdown', async () => {
+		const items = [
+			{ id: '1', label: 'Item 1' },
+			{ id: '2', label: 'Item 2' },
+			{ id: '3', label: 'Item 3' }
+		] satisfies DropdownItem[];
+		const { user } = setup(
+			<Dropdown items={items} placement="bottom-end">
+				<Button icon="ArrowDown" label="Create" onClick={jest.fn()} />
+			</Dropdown>
+		);
+
+		await user.click(screen.getByRole('button'));
+		expect(screen.getByText(items[0].label)).toBeVisible();
+
+		fireEvent.scroll(screen.getByText(items[1].label));
+
+		expect(screen.getByText(items[0].label)).toBeInTheDocument();
 	});
 
 	describe('Keyboard shortcuts', () => {

--- a/src/components/display/Dropdown.tsx
+++ b/src/components/display/Dropdown.tsx
@@ -574,23 +574,23 @@ const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(function Dropdo
 		[disabled, openPopper]
 	);
 
-	const clickOutsidePopper = useCallback(
+	const handleOutsidePopperInteraction = useCallback(
 		(e: Event) => {
-			const clickedOnDropdown =
+			const isInteractingWithDropdown =
 				dropdownRef.current &&
 				(e.target === dropdownRef.current || dropdownRef.current.contains(e.target as Node | null));
-			const clickedOnTrigger =
+			const isInteractingWithTrigger =
 				!contextMenu &&
 				innerTriggerRef.current &&
 				(e.target === innerTriggerRef.current ||
 					innerTriggerRef.current?.contains(e.target as Node | null));
-			const clickedOnNestedItem = nestedDropdownsRef.current?.some((nestedItemRef) =>
+			const isInteractingWithNestedDropdown = nestedDropdownsRef.current?.some((nestedItemRef) =>
 				nestedItemRef.current?.contains(e.target as Node | null)
 			);
 			if (
-				!clickedOnDropdown &&
-				!clickedOnTrigger &&
-				!clickedOnNestedItem &&
+				!isInteractingWithDropdown &&
+				!isInteractingWithTrigger &&
+				!isInteractingWithNestedDropdown &&
 				// check if the attribute is in the event path
 				!e
 					.composedPath?.()
@@ -730,15 +730,18 @@ const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(function Dropdo
 
 	useEffect(() => {
 		if (open) {
-			windowObj.document.addEventListener('click', clickOutsidePopper, true);
-			contextMenu && windowObj.document.addEventListener('contextmenu', clickOutsidePopper, true);
+			windowObj.document.addEventListener('click', handleOutsidePopperInteraction, true);
+			windowObj.document.addEventListener('scroll', handleOutsidePopperInteraction, true);
+			contextMenu &&
+				windowObj.document.addEventListener('contextmenu', handleOutsidePopperInteraction, true);
 		}
 
 		return (): void => {
-			windowObj.document.removeEventListener('click', clickOutsidePopper, true);
-			windowObj.document.removeEventListener('contextmenu', clickOutsidePopper, true);
+			windowObj.document.removeEventListener('click', handleOutsidePopperInteraction, true);
+			windowObj.document.removeEventListener('scroll', handleOutsidePopperInteraction, true);
+			windowObj.document.removeEventListener('contextmenu', handleOutsidePopperInteraction, true);
 		};
-	}, [open, closePopper, clickOutsidePopper, contextMenu, windowObj.document]);
+	}, [open, closePopper, handleOutsidePopperInteraction, contextMenu, windowObj.document]);
 
 	useEffect(() => {
 		const startSentinelRefElement = startSentinelRef.current;


### PR DESCRIPTION
If the user scrolls the document or any container that is outside of the dropdown, the component will detect the scroll event and close itself.
This prevents scenarios where the dropdown remains open after its parent components have changed position due to scrolling.
Refs: CDS-314