### PR TITLE
fix: date time picker onChange handler is triggered every time defaultValue changes

### DIFF
--- a/src/components/inputs/datetimePicker/DateTimePicker.test.tsx
+++ b/src/components/inputs/datetimePicker/DateTimePicker.test.tsx
@@ -34,27 +34,35 @@ describe('DateTimePicker', () => {
 			expect(onChangeFn).not.toHaveBeenCalled();
 		});
 
-		it.each([
-			{
-				label: 'label',
-				defaultValue: null
-			},
-			{
-				label: 'label',
-				defaultValue: new Date(2011, 5, 2)
-			},
-			{
-				label: 'label',
-				defaultValue: new Date(2011, 5, 2),
-				selected: null
-			},
-			{
-				label: 'label',
-				defaultValue: new Date(2011, 5, 2),
-				selected: new Date(2012, 5, 2)
-			}
+		test.each([
+			[
+				{
+					label: 'label',
+					defaultValue: null
+				}
+			],
+			[
+				{
+					label: 'label',
+					defaultValue: new Date(2011, 5, 2)
+				}
+			],
+			[
+				{
+					label: 'label',
+					defaultValue: new Date(2011, 5, 2),
+					selected: null
+				}
+			],
+			[
+				{
+					label: 'label',
+					defaultValue: new Date(2011, 5, 2),
+					selected: new Date(2012, 5, 2)
+				}
+			]
 		])(
-			'With props (add props) - When a new value is set, onChange prop is called once',
+			'With props %p - When a new value is set, onChange prop is called once',
 			async (props: DateTimePickerProps) => {
 				const onChangeFn = jest.fn();
 				const propsToUse: DateTimePickerProps = {

--- a/src/components/inputs/datetimePicker/DateTimePicker.test.tsx
+++ b/src/components/inputs/datetimePicker/DateTimePicker.test.tsx
@@ -34,17 +34,43 @@ describe('DateTimePicker', () => {
 			expect(onChangeFn).not.toHaveBeenCalled();
 		});
 
-		it('When a new value is set, onChange prop is called once', async () => {
-			const onChangeFn = jest.fn();
-			const { user } = setup(<DateTimePicker label={'label'} onChange={onChangeFn} />);
-			const inputElement = screen.getByRole('textbox');
-			const now = new Date();
-			const dateString = format(now, 'MM/dd/yyyy HH:mm');
-			const parsedDateString = new Date(Date.parse(dateString));
-			await user.type(inputElement, dateString);
-			await user.keyboard('[Enter]');
-			expect(onChangeFn).toHaveBeenCalledTimes(1);
-		});
+		it.each([
+			{
+				label: 'label',
+				defaultValue: null
+			},
+			{
+				label: 'label',
+				defaultValue: new Date(2011, 5, 2)
+			},
+			{
+				label: 'label',
+				defaultValue: new Date(2011, 5, 2),
+				selected: null
+			},
+			{
+				label: 'label',
+				defaultValue: new Date(2011, 5, 2),
+				selected: new Date(2012, 5, 2)
+			}
+		])(
+			'With props (add props) - When a new value is set, onChange prop is called once',
+			async (props: DateTimePickerProps) => {
+				const onChangeFn = jest.fn();
+				const propsToUse: DateTimePickerProps = {
+					...props,
+					onChange: onChangeFn
+				};
+				const { user } = setup(<DateTimePicker {...propsToUse} />);
+				const inputElement = screen.getByRole('textbox');
+				const now = new Date();
+				const dateString = format(now, 'MM/dd/yyyy HH:mm');
+				const parsedDateString = new Date(Date.parse(dateString));
+				await user.type(inputElement, dateString);
+				await user.keyboard('[Enter]');
+				expect(onChangeFn).toHaveBeenCalledTimes(1);
+			}
+		);
 
 		it('should update when defaultValue changes', async () => {
 			const onChangeFn = jest.fn();

--- a/src/components/inputs/datetimePicker/DateTimePicker.test.tsx
+++ b/src/components/inputs/datetimePicker/DateTimePicker.test.tsx
@@ -28,6 +28,24 @@ describe('DateTimePicker', () => {
 			).toBeVisible();
 		});
 
+		it('should render the component without invoking onChange', async () => {
+			const onChangeFn = jest.fn();
+			const { user } = setup(<DateTimePicker label={'label'} onChange={onChangeFn} />);
+			expect(onChangeFn).not.toHaveBeenCalled();
+		});
+
+		it('When a new value is set, onChange prop is called once', async () => {
+			const onChangeFn = jest.fn();
+			const { user } = setup(<DateTimePicker label={'label'} onChange={onChangeFn} />);
+			const inputElement = screen.getByRole('textbox');
+			const now = new Date();
+			const dateString = format(now, 'MM/dd/yyyy HH:mm');
+			const parsedDateString = new Date(Date.parse(dateString));
+			await user.type(inputElement, dateString);
+			await user.keyboard('[Enter]');
+			expect(onChangeFn).toHaveBeenCalledTimes(1);
+		});
+
 		test('Click on the input opens the picker', async () => {
 			const { user } = setup(<DateTimePicker label={'The label'} />);
 			await user.click(screen.getByRole('textbox'));

--- a/src/components/inputs/datetimePicker/DateTimePicker.test.tsx
+++ b/src/components/inputs/datetimePicker/DateTimePicker.test.tsx
@@ -5,12 +5,12 @@
  */
 import React from 'react';
 
-import { format, addMonths, startOfMonth } from 'date-fns';
+import { addMonths, format, startOfMonth } from 'date-fns';
 
 import type { DateTimePickerProps } from './DateTimePicker';
 import { DateTimePicker } from './DateTimePicker';
 import { ICONS, SELECTORS } from '../../../tests/constants';
-import { setup, screen, within } from '../../../tests/utils';
+import { screen, setup, within } from '../../../tests/utils';
 import { Button } from '../../basic/button/Button';
 
 const DEFAULT_DATE_FORMAT = 'MMMM d, yyyy h:mm aa';
@@ -44,6 +44,20 @@ describe('DateTimePicker', () => {
 			await user.type(inputElement, dateString);
 			await user.keyboard('[Enter]');
 			expect(onChangeFn).toHaveBeenCalledTimes(1);
+		});
+
+		it('should update when defaultValue changes', async () => {
+			const onChangeFn = jest.fn();
+			const firstDate = new Date(2010, 0, 1);
+			const { user, rerender } = setup(
+				<DateTimePicker label={'label'} defaultValue={firstDate} onChange={onChangeFn} />
+			);
+			expect(screen.getByRole('textbox')).toHaveValue('January 1, 2010 12:00 AM');
+
+			const secondDate = new Date(2025, 0, 1);
+			rerender(<DateTimePicker label={'label'} defaultValue={secondDate} onChange={onChangeFn} />);
+
+			expect(screen.getByRole('textbox')).toHaveValue('January 1, 2025 12:00 AM');
 		});
 
 		test('Click on the input opens the picker', async () => {

--- a/src/components/inputs/datetimePicker/DateTimePicker.tsx
+++ b/src/components/inputs/datetimePicker/DateTimePicker.tsx
@@ -121,7 +121,7 @@ const DateTimePicker = React.forwardRef<DatePicker, DateTimePickerProps>(functio
 	const updateDateTimeState = useCallback<
 		(
 			action:
-				| { type: 'SAVE' | 'SAVE_AND_UPDATE' | 'DEFAULT_VALUE_CHANGED'; value: Date | null }
+				| { type: 'SAVE' | 'SAVE_AND_UPDATE'; value: Date | null }
 				| { type: 'UPDATE'; value?: never }
 		) => void
 	>(
@@ -134,10 +134,6 @@ const DateTimePicker = React.forwardRef<DatePicker, DateTimePickerProps>(functio
 				case 'UPDATE':
 					setDateTime(currentValue);
 					onChange?.(currentValue);
-					break;
-				case 'DEFAULT_VALUE_CHANGED':
-					dateTimeRef.current = newValue;
-					setDateTime(newValue);
 					break;
 				case 'SAVE_AND_UPDATE':
 					dateTimeRef.current = newValue;
@@ -152,8 +148,9 @@ const DateTimePicker = React.forwardRef<DatePicker, DateTimePickerProps>(functio
 	);
 
 	useEffect(() => {
-		updateDateTimeState({ type: 'DEFAULT_VALUE_CHANGED', value: defaultValue });
-	}, [defaultValue, updateDateTimeState]);
+		dateTimeRef.current = defaultValue;
+		setDateTime(defaultValue);
+	}, [defaultValue]);
 
 	const onClear = useCallback(() => {
 		updateDateTimeState({ type: 'SAVE_AND_UPDATE', value: null });

--- a/src/components/inputs/datetimePicker/DateTimePicker.tsx
+++ b/src/components/inputs/datetimePicker/DateTimePicker.tsx
@@ -121,8 +121,7 @@ const DateTimePicker = React.forwardRef<DatePicker, DateTimePickerProps>(functio
 	const updateDateTimeState = useCallback<
 		(
 			action:
-				| { type: 'SAVE' | 'SAVE_AND_UPDATE'; value: Date | null }
-				| { type: 'SAVE' | 'DEFAULT_VALUE_CHANGED'; value: Date | null }
+				| { type: 'SAVE' | 'SAVE_AND_UPDATE' | 'DEFAULT_VALUE_CHANGED'; value: Date | null }
 				| { type: 'UPDATE'; value?: never }
 		) => void
 	>(

--- a/src/components/inputs/datetimePicker/DateTimePicker.tsx
+++ b/src/components/inputs/datetimePicker/DateTimePicker.tsx
@@ -122,6 +122,7 @@ const DateTimePicker = React.forwardRef<DatePicker, DateTimePickerProps>(functio
 		(
 			action:
 				| { type: 'SAVE' | 'SAVE_AND_UPDATE'; value: Date | null }
+				| { type: 'SAVE' | 'DEFAULT_VALUE_CHANGED'; value: Date | null }
 				| { type: 'UPDATE'; value?: never }
 		) => void
 	>(
@@ -134,6 +135,10 @@ const DateTimePicker = React.forwardRef<DatePicker, DateTimePickerProps>(functio
 				case 'UPDATE':
 					setDateTime(currentValue);
 					onChange?.(currentValue);
+					break;
+				case 'DEFAULT_VALUE_CHANGED':
+					dateTimeRef.current = newValue;
+					setDateTime(newValue);
 					break;
 				case 'SAVE_AND_UPDATE':
 					dateTimeRef.current = newValue;
@@ -148,7 +153,7 @@ const DateTimePicker = React.forwardRef<DatePicker, DateTimePickerProps>(functio
 	);
 
 	useEffect(() => {
-		updateDateTimeState({ type: 'SAVE_AND_UPDATE', value: defaultValue });
+		updateDateTimeState({ type: 'DEFAULT_VALUE_CHANGED', value: defaultValue });
 	}, [defaultValue, updateDateTimeState]);
 
 	const onClear = useCallback(() => {


### PR DESCRIPTION
The onChange handler should be triggered only when the user picks a different date.

Ref:
 - CDS-325
 - CO-2006
