### PR TITLE
refactor: avoid showing warning on console by replacing :first-child

### DIFF
--- a/src/components/display/Chip.tsx
+++ b/src/components/display/Chip.tsx
@@ -131,7 +131,7 @@ const ActionContainer = styled.div<{ $spacing: string }>`
 const LabelContainer = styled(Container)``;
 
 const ContentContainer = styled(Container)`
-	&:first-child > ${LabelContainer}:first-child {
+	&:first-of-type > ${LabelContainer}:first-of-type {
 		padding-left: ${({ gap }): string => `calc(${gap} * 2)`};
 	}
 	& > ${LabelContainer}:last-child {

--- a/src/components/feedback/banner/Banner.tsx
+++ b/src/components/feedback/banner/Banner.tsx
@@ -62,7 +62,7 @@ const InfoContainer = styled(Container)`
 	display: -webkit-box;
 	-webkit-line-clamp: 3;
 	-webkit-box-orient: vertical;
-	& > *:not(:is(:first-of-type)) {
+	& > * + * {
 		padding-top: 0.25rem;
 	}
 `;

--- a/src/components/feedback/banner/Banner.tsx
+++ b/src/components/feedback/banner/Banner.tsx
@@ -62,7 +62,7 @@ const InfoContainer = styled(Container)`
 	display: -webkit-box;
 	-webkit-line-clamp: 3;
 	-webkit-box-orient: vertical;
-	& > *:not(:is(:first-child)) {
+	& > *:not(:is(:first-of-type)) {
 		padding-top: 0.25rem;
 	}
 `;

--- a/src/components/feedback/modal-components/ModalFooter.tsx
+++ b/src/components/feedback/modal-components/ModalFooter.tsx
@@ -30,7 +30,7 @@ const ButtonContainer = styled(Container)<{ $pushLeftFirstChild?: boolean }>`
 		$pushLeftFirstChild &&
 		css`
 			> * {
-				&:first-child {
+				&:first-of-type {
 					margin-right: auto;
 				}
 			}


### PR DESCRIPTION
**problem description**: https://github.com/emotion-js/emotion/issues/1105#issue-390628190

**possibile solutions**:
- disable warning https://github.com/emotion-js/emotion/issues/1105#issuecomment-459726361
- replace `:first-child` with `:first-of-type` (same behavior since almost all the components of the CDS are `div`s)
- other [possibile solutions](https://github.com/emotion-js/emotion/issues/1105#issuecomment-557726922) 

**possible modules affected**:
- **carbonio-search-ui** (`:first-child` can be removed directly since it is useless in that case)
- **carbonio-calendars-ui**: probably better NOT to replace with `:first-of-type` (second option)

Refs: CO-2532