### PR TITLE
Fix accordion transitions

### DIFF
--- a/src/components/navigation/Accordion.test.tsx
+++ b/src/components/navigation/Accordion.test.tsx
@@ -151,7 +151,7 @@ describe('Accordion', () => {
 		expect(screen.queryByTestId(ICONS.accordionItemOpenAction)).not.toBeInTheDocument();
 		// click on chevron icon of opened accordion close the accordion and does not call onClick callback
 		await user.click(screen.getByTestId(ICONS.accordionItemCloseAction));
-		await waitFor(() => expect(screen.getByText(/second/i)).not.toBeVisible());
+		await waitFor(() => expect(screen.queryByText(/second/i)).not.toBeInTheDocument());
 		expect(onClick).toHaveBeenCalledTimes(1);
 		expect(screen.getByTestId(ICONS.accordionItemOpenAction)).toBeVisible();
 		expect(screen.queryByTestId(ICONS.accordionItemCloseAction)).not.toBeInTheDocument();

--- a/src/components/navigation/Accordion.tsx
+++ b/src/components/navigation/Accordion.tsx
@@ -5,6 +5,7 @@
  */
 
 import React, { useMemo, useState, useCallback, useEffect } from 'react';
+import type { SyntheticEvent } from 'react';
 
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -12,6 +13,7 @@ import { map } from 'lodash';
 
 import { useCombinedRefs } from '../../hooks/useCombinedRefs';
 import { useKeyboard, getKeyboardPreset } from '../../hooks/useKeyboard';
+import { isTestEnvironment } from '../../tests/test-environment';
 import type { Theme } from '../../theme/theme';
 import { getColor, pseudoClasses } from '../../theme/theme-utils';
 import { Badge } from '../basic/badge/Badge';
@@ -158,8 +160,13 @@ const AccordionRoot = React.forwardRef<HTMLDivElement, AccordionRootProps>(funct
 	ref
 ) {
 	const [open, setOpen] = useState(!!item.open);
-	const [areItemsVisible, setAreItemsVisible] = useState(open);
+	const [areItemsVisible, setAreItemsVisible] = useState(!!item.open);
 	const accordionRef = useCombinedRefs<HTMLDivElement>(ref);
+
+	const isTransitionDisabled = useMemo(
+		() => disableTransition || isTestEnvironment(),
+		[disableTransition]
+	);
 
 	// Set the initial open state
 	useEffect(() => {
@@ -185,30 +192,30 @@ const AccordionRoot = React.forwardRef<HTMLDivElement, AccordionRootProps>(funct
 	const toggleOpen = useCallback(
 		(e: KeyboardEvent | React.SyntheticEvent) => {
 			e.stopPropagation();
-
 			/*
 			 * If the transition is disabled or the accordion is not open,
 			 * we immediately sync the areItemsVisible state with the next value
 			 */
-			if (disableTransition || !open) {
+			if (isTransitionDisabled || !open) {
 				setAreItemsVisible(!open);
+				open ? item.onClose && item.onClose(e) : item.onOpen && item.onOpen(e);
 			}
-
-			setOpen((op) => {
-				op ? item.onClose && item.onClose(e) : item.onOpen && item.onOpen(e);
-				return !op;
-			});
+			setOpen((op) => !op);
 		},
-		[item, disableTransition, open]
+		[item, isTransitionDisabled, open]
 	);
 
 	/*
 	 * At the end of the collapse transition, we want to sync the areItemsVisible state
 	 * with the open state
 	 */
-	const onCollapseTransitionEnd = useCallback(() => {
-		setAreItemsVisible(() => open);
-	}, [open]);
+	const onCollapseTransitionEnd = useCallback(
+		(event: SyntheticEvent) => {
+			setAreItemsVisible(() => open);
+			open ? item.onOpen && item.onOpen(event) : item.onClose && item.onClose(event);
+		},
+		[open, item]
+	);
 
 	const hasItems = useMemo(() => item.items && item.items.length > 0, [item.items]);
 
@@ -281,7 +288,7 @@ const AccordionRoot = React.forwardRef<HTMLDivElement, AccordionRootProps>(funct
 					crossSize="100%"
 					orientation="vertical"
 					open={open}
-					disableTransition={disableTransition}
+					disableTransition={isTransitionDisabled}
 					onTransitionEnd={onCollapseTransitionEnd}
 				>
 					{/* eslint-disable-next-line @typescript-eslint/no-use-before-define */}
@@ -292,7 +299,7 @@ const AccordionRoot = React.forwardRef<HTMLDivElement, AccordionRootProps>(funct
 						items={item.items!}
 						level={item.level ?? level + 1}
 						background={background}
-						disableTransition={disableTransition}
+						disableTransition={isTransitionDisabled}
 					/>
 				</Collapse>
 			)}
@@ -337,6 +344,10 @@ const Accordion = React.forwardRef<HTMLDivElement, AccordionProps>(function Acco
 	},
 	ref
 ) {
+	const isTransitionDisabled = useMemo(
+		() => disableTransition || isTestEnvironment(),
+		[disableTransition]
+	);
 	return (
 		<Container
 			orientation="vertical"
@@ -359,7 +370,7 @@ const Accordion = React.forwardRef<HTMLDivElement, AccordionProps>(function Acco
 						background={background}
 						activeId={activeId}
 						openIds={openIds}
-						disableTransition={disableTransition}
+						disableTransition={isTransitionDisabled}
 						expandLabel={expandLabel}
 						collapseLabel={collapseLabel}
 					/>

--- a/src/components/utilities/Collapse.tsx
+++ b/src/components/utilities/Collapse.tsx
@@ -12,6 +12,7 @@ import styled from '@emotion/styled';
 
 import { Transition } from './Transition';
 import { useCombinedRefs } from '../../hooks/useCombinedRefs';
+import { isTestEnvironment } from '../../tests/test-environment';
 import { Container } from '../layout/container/Container';
 
 const CollapseEl = styled.div<{
@@ -55,6 +56,11 @@ const Collapse = React.forwardRef<HTMLElement, CollapseProps>(function CollapseF
 	{ children, open, orientation = 'horizontal', crossSize, disableTransition = false, ...rest },
 	ref
 ) {
+	const isTransitionDisabled = useMemo(
+		() => disableTransition || isTestEnvironment(),
+		[disableTransition]
+	);
+
 	const collapseRef = useCombinedRefs<HTMLElement>(ref);
 
 	const propToTransition = useMemo<'width' | 'height'>(
@@ -89,13 +95,13 @@ const Collapse = React.forwardRef<HTMLElement, CollapseProps>(function CollapseF
 				visibility: 'visible',
 				pointerEvents: 'auto'
 			}}
-			disabled={disableTransition}
+			disabled={isTransitionDisabled}
 		>
 			<CollapseEl
 				$crossSize={crossSize}
 				$open={open}
 				$orientation={orientation}
-				$disableTransition={disableTransition}
+				$disableTransition={isTransitionDisabled}
 				{...rest}
 			>
 				{children}

--- a/src/components/utilities/Transition.tsx
+++ b/src/components/utilities/Transition.tsx
@@ -13,6 +13,7 @@ import type {
 import React, { useEffect, useMemo } from 'react';
 
 import { useCombinedRefs } from '../../hooks/useCombinedRefs';
+import { isTestEnvironment } from '../../tests/test-environment';
 
 type CSSObject = {
 	[K in keyof CSSProperties]: CSSProperties[K] | (() => NonNullable<CSSProperties[K]>);
@@ -241,7 +242,11 @@ const Transition: ForwardRefExoticComponent<
 	PropsWithoutRef<TransitionProps> & RefAttributes<HTMLElement>
 > & { types?: Array<keyof typeof STYLES> } = React.forwardRef<HTMLElement, TransitionProps>(
 	function TransitionFn({ disabled, children, ...rest }, ref) {
-		if (disabled) return React.cloneElement(children, { ref });
+		const isTransitionDisabled = useMemo(() => disabled || isTestEnvironment(), [disabled]);
+
+		if (isTransitionDisabled) {
+			return React.cloneElement(children, { ref });
+		}
 
 		return (
 			<TransitionOn ref={ref} {...rest}>

--- a/src/tests/test-environment.ts
+++ b/src/tests/test-environment.ts
@@ -1,0 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export const isTestEnvironment: () => boolean = () => process.env.NODE_ENV === 'test';


### PR DESCRIPTION
This pull request improves the reliability and consistency of the Accordion and Collapse components, especially in test environments, by ensuring that transitions are disabled during tests. This prevents flaky behavior and timing issues in automated testing. The most important changes are grouped below:

**Test Environment Handling**

* Added a new utility function `isTestEnvironment` in `src/tests/test-environment.ts` to detect when the code is running in a test environment.
* Updated `Accordion`, `AccordionRoot`, `Collapse`, and `Transition` components to use `isTestEnvironment` so that transitions are automatically disabled during tests, regardless of the `disableTransition` prop. [[1]](diffhunk://#diff-7daa79330712686882af70c13909b47c430033b144e0ccde064267e15f69e2c7R8-R16) [[2]](diffhunk://#diff-eb4698412958093b6a5131493ccaf0ad27c4aa12faa49728966744436f43c1c8R15) [[3]](diffhunk://#diff-f09d17af24ca9d40fb529c7048ad995df74c70e5e5c0934929d194b57c4731edR16)

**Component Logic Updates**

* Refactored transition disabling logic in `Accordion`, `AccordionRoot`, `Collapse`, and `Transition` to consistently use the new `isTransitionDisabled` variable, which combines both the `disableTransition` prop and the test environment check. [[1]](diffhunk://#diff-7daa79330712686882af70c13909b47c430033b144e0ccde064267e15f69e2c7L161-R170) [[2]](diffhunk://#diff-7daa79330712686882af70c13909b47c430033b144e0ccde064267e15f69e2c7L188-R218) [[3]](diffhunk://#diff-7daa79330712686882af70c13909b47c430033b144e0ccde064267e15f69e2c7L284-R291) [[4]](diffhunk://#diff-7daa79330712686882af70c13909b47c430033b144e0ccde064267e15f69e2c7L295-R302) [[5]](diffhunk://#diff-7daa79330712686882af70c13909b47c430033b144e0ccde064267e15f69e2c7R347-R350) [[6]](diffhunk://#diff-7daa79330712686882af70c13909b47c430033b144e0ccde064267e15f69e2c7L362-R373) [[7]](diffhunk://#diff-eb4698412958093b6a5131493ccaf0ad27c4aa12faa49728966744436f43c1c8R59-R63) [[8]](diffhunk://#diff-eb4698412958093b6a5131493ccaf0ad27c4aa12faa49728966744436f43c1c8L92-R104) [[9]](diffhunk://#diff-f09d17af24ca9d40fb529c7048ad995df74c70e5e5c0934929d194b57c4731edL244-R249)

**Testing fix**

* Fixed Accordion tests to use `queryByText` instead of `getByText`