### PR TITLE
chore: retarget devel branch refs to main

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ pipeline {
                     script {
                         isReleaseBranch = "${BRANCH_NAME}" ==~ /release/
                         echo "isReleaseBranch: ${isReleaseBranch}"
-                        isDevelBranch = "${BRANCH_NAME}" ==~ /devel/
+                        isDevelBranch = env.BRANCH_IS_PRIMARY == 'true'
                         echo "isDevelBranch: ${isDevelBranch}"
                         isPullRequest = "${BRANCH_NAME}" ==~ /PR-\d+/
                         echo "isPullRequest: ${isPullRequest}"

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -3,7 +3,7 @@
  */
 export default {
 	branches: [
-		'devel'
+		'main'
 	],
 	plugins: [
 		[


### PR DESCRIPTION
Ahead of the devel→main default-branch rename. `release.config.mjs` branches retargeted to `main` (semantic-release has no env-var interpolation, must be literal). `Jenkinsfile`'s `isDevelBranch` flag (gates SonarQube, doc-playground deploy, visual-test-image push) now uses `env.BRANCH_IS_PRIMARY` instead of a hardcoded `/devel/` regex.