### PR TITLE
fix(ci): use sonar-scanner-npm bin to match sonarqube-scanner 5.x

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -198,7 +198,7 @@ pipeline {
                         sh 'pnpm add -D sonarqube-scanner'
                     }
                     withSonarQubeEnv(credentialsId: 'sonarqube-user-token', installationName: 'SonarQube instance') {
-                        sh "pnpm exec sonar-scanner -Dsonar.projectKey=${getPackageName().replaceAll("@zextras/", "")} -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info"
+                        sh "pnpm exec sonar-scanner-npm -Dsonar.projectKey=${getPackageName().replaceAll("@zextras/", "")} -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info"
                     }
                 }
             }


### PR DESCRIPTION
The sonarqube-scanner npm package renamed its CLI bin from sonar-scanner to sonar-scanner-npm starting with v5.0.0, breaking the SonarQube analysis stage in Jenkins.